### PR TITLE
[Design] 담당자 연락처 입력 뷰 레이아웃 그리기

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		26E3749628FCF56400997DA7 /* RoomListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749528FCF56400997DA7 /* RoomListViewController.swift */; };
 		26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */; };
 		26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749728FD2D0700997DA7 /* RoomListCell.swift */; };
+		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */; };
 		98C0D06428FCE99300E0E439 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06328FCE99300E0E439 /* JSON.swift */; };
 		98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06628FCE9DC00E0E439 /* Model.swift */; };
@@ -38,6 +39,7 @@
 		26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		26E3749D28FE95D100997DA7 /* Samsam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Samsam.entitlements; sourceTree = "<group>"; };
 		26E3749728FD2D0700997DA7 /* RoomListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListCell.swift; sourceTree = "<group>"; };
+		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayout+.swift"; sourceTree = "<group>"; };
 		98C0D06328FCE99300E0E439 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		98C0D06628FCE9DC00E0E439 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				98C0D06D28FCF46A00E0E439 /* WorkingHistoryView */,
 				26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */,
 				26E3749728FD2D0700997DA7 /* RoomListCell.swift */,
+				26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -246,6 +249,7 @@
 				98C0D06A28FCEA4900E0E439 /* ImagePicker.swift in Sources */,
 				26E3748228FCDC0000997DA7 /* AppDelegate.swift in Sources */,
 				26E3748428FCDC0000997DA7 /* SceneDelegate.swift in Sources */,
+				26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */,
 				98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */,
 				26E3749628FCF56400997DA7 /* RoomListViewController.swift in Sources */,
 			);

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -1,0 +1,131 @@
+//
+//  PhoneNumViewController.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/18.
+//
+
+import UIKit
+
+class PhoneNumViewController: UIViewController {
+    
+    // MARK: - View
+    
+    private let vStack: UIStackView = {
+        $0.axis = .vertical
+        return $0
+    }(UIStackView())
+    
+    private let numberLabel: UILabel = {
+        $0.text = "담당자 연락처를 입력해주세요."
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        return $0
+    }(UILabel())
+    
+    private let hStack: UIStackView = {
+        $0.axis = .horizontal
+        return $0
+    }(UIStackView())
+    
+    private let startNumber: UILabel = {
+        $0.text = "010 - "
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        return $0
+    }(UILabel())
+    
+    private lazy var numberInput: UITextField = {
+        $0.placeholder = "1234-5678"
+        $0.font = UIFont.systemFont(ofSize: 16)
+        return $0
+    }(UITextField())
+    
+    private let inputUnderLine: UIView = {
+        $0.setHeight(height: 1)
+        $0.backgroundColor = .gray
+        return $0
+    }(UIView())
+    
+    private let submitButton: UIButton = {
+        $0.setTitle("확인", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.backgroundColor = .blue
+        $0.setHeight(height: 60)
+        $0.layer.cornerRadius = 16
+        return $0
+    }(UIButton())
+    
+    // MARK: - LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        attribute()
+        layout()
+    }
+    
+    // MARK: - Method
+    
+    private func attribute() {
+        view.backgroundColor = .white
+    }
+    
+    private func layout() {
+        view.addSubview(vStack)
+        
+        vStack.addArrangedSubview(numberLabel)
+        vStack.addArrangedSubview(hStack)
+        hStack.addArrangedSubview(startNumber)
+        hStack.addArrangedSubview(numberInput)
+        vStack.addArrangedSubview(inputUnderLine)
+        vStack.addArrangedSubview(submitButton)
+        
+        vStack.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 16,
+            paddingBottom: 16,
+            paddingRight: 16
+        )
+        
+        numberLabel.anchor(
+            left: vStack.leftAnchor,
+            bottom: hStack.topAnchor,
+            right: vStack.rightAnchor
+        )
+        
+        hStack.anchor(
+            left: vStack.leftAnchor,
+            bottom: inputUnderLine.topAnchor,
+            right: vStack.rightAnchor
+        )
+        
+        startNumber.anchor(
+            top: hStack.topAnchor,
+            left: hStack.leftAnchor,
+            bottom: hStack.bottomAnchor,
+            right: numberInput.leftAnchor
+        )
+        
+        numberInput.anchor(
+            top: hStack.topAnchor,
+            bottom: hStack.bottomAnchor,
+            right: hStack.rightAnchor
+        )
+        
+        inputUnderLine.anchor(
+            left: vStack.leftAnchor,
+            bottom: submitButton.topAnchor,
+            right: vStack.rightAnchor,
+            paddingBottom: 30
+        )
+        
+        submitButton.anchor(
+            left: vStack.leftAnchor,
+            bottom: vStack.bottomAnchor,
+            right: vStack.rightAnchor
+        )
+    }
+}

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -50,7 +50,7 @@ class PhoneNumViewController: UIViewController {
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         $0.backgroundColor = .blue
-        $0.setHeight(height: 60)
+        $0.setHeight(height: 50)
         $0.layer.cornerRadius = 16
         return $0
     }(UIButton())


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 고객이 업자에게 쉽게 연락할 수 있도록 앱 내에서 전화로 이어지는 기능의 추가가 필요하여 업자의 연락처를 받아야 했음
- 애플 로그인 API에서는 해당 아이디 사용자의 연락처를 받아올 수 없음
- 별도의 뷰에서 업자의 연락처를 받아와야했기 때문에 담당자 연락처를 입력받을 수 있는 뷰가 필요하여 코드 추가

## Key Changes 🔥 (주요 구현/변경 사항)
- PhoneNumView 레이아웃 생성

## ToDo 📆 (남은 작업)
- [ ] 연락처를 입력했을 때, 올바른 형식인지 확인하고 올바른 형식일 때만 다음 뷰로 넘어가는 기능 추가
- [ ] 버튼 색 변경
- [ ] 온보딩 추가

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/196389064-90f7ad44-7acf-4d15-9116-54458cd700ae.gif" width=300>

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 뷰 그리기 작업입니다. 가볍게 리뷰해 주셔도 좋습니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #18.
