### PR TITLE
[Design] 담당자 연락처 입력 뷰 레이아웃 수정

### DIFF
--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -11,10 +11,9 @@ class PhoneNumViewController: UIViewController {
     
     // MARK: - View
     
-    private let vStack: UIStackView = {
-        $0.axis = .vertical
+    private let uiView: UIView = {
         return $0
-    }(UIStackView())
+    }(UIView())
     
     private let numberLabel: UILabel = {
         $0.text = "담당자 연락처를 입력해주세요."
@@ -71,16 +70,16 @@ class PhoneNumViewController: UIViewController {
     }
     
     private func layout() {
-        view.addSubview(vStack)
+        view.addSubview(uiView)
         
-        vStack.addArrangedSubview(numberLabel)
-        vStack.addArrangedSubview(hStack)
+        uiView.addSubview(numberLabel)
+        uiView.addSubview(hStack)
         hStack.addArrangedSubview(startNumber)
         hStack.addArrangedSubview(numberInput)
-        vStack.addArrangedSubview(inputUnderLine)
-        vStack.addArrangedSubview(submitButton)
+        uiView.addSubview(inputUnderLine)
+        uiView.addSubview(submitButton)
         
-        vStack.anchor(
+        uiView.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
@@ -91,15 +90,16 @@ class PhoneNumViewController: UIViewController {
         )
         
         numberLabel.anchor(
-            left: vStack.leftAnchor,
+            left: uiView.leftAnchor,
             bottom: hStack.topAnchor,
-            right: vStack.rightAnchor
+            right: uiView.rightAnchor,
+            paddingBottom: 20
         )
         
         hStack.anchor(
-            left: vStack.leftAnchor,
+            left: uiView.leftAnchor,
             bottom: inputUnderLine.topAnchor,
-            right: vStack.rightAnchor
+            right: uiView.rightAnchor
         )
         
         startNumber.anchor(
@@ -116,16 +116,16 @@ class PhoneNumViewController: UIViewController {
         )
         
         inputUnderLine.anchor(
-            left: vStack.leftAnchor,
+            left: uiView.leftAnchor,
             bottom: submitButton.topAnchor,
-            right: vStack.rightAnchor,
+            right: uiView.rightAnchor,
             paddingBottom: 30
         )
         
         submitButton.anchor(
-            left: vStack.leftAnchor,
-            bottom: vStack.bottomAnchor,
-            right: vStack.rightAnchor
+            left: uiView.leftAnchor,
+            bottom: uiView.bottomAnchor,
+            right: uiView.rightAnchor
         )
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- Figma에 그려진 LoFi와 달랐던 담당자 연락처 입력 뷰 상단의 패딩을 LoFi에 맞게 변경하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- PhoneNumView 상단 패딩 조정

## ToDo 📆 (남은 작업)
- [ ] 담당자 연락처 입력 뷰 기능 추가

## ScreenShot 📷 (참고 사진)
<img width="300" alt="스크린샷 2022-10-19 17 40 16" src="https://user-images.githubusercontent.com/81027256/196641437-b4a22e8e-cca1-4faf-88b9-5db860b850d9.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 매우 짧은 코드 수정입니다. 가볍게 리뷰해주셔도 좋습니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #21.
