### PR TITLE
[Refactor] DetailView 전역변수 제거

### DIFF
--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -149,7 +149,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "수정",
                                                             style: .plain,
                                                             target: self,
-                                                            action: nil
+                                                            action: #selector(tapEditButton) 
         )
     }
     
@@ -160,6 +160,13 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     @objc func pageDidChange(sender: UIPageControl){
         let offsetX = components.screenWidth * CGFloat(pageControl.currentPage)
         scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
+    }
+    
+    // TODO: - 수정화면 생성되면 수정예정.
+    
+    @objc func tapEditButton() {
+        let editViewController = ViewController()
+        navigationController?.pushViewController(editViewController, animated: true)
     }
 }
 

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -7,33 +7,24 @@
 
 import UIKit
 
-struct Components {
-    
-    // TODO: - 서버연결 시 TestImage 삭제
-    
-    var images = ["Test01","Test02","Test03","Test04"]
-    let screenWidth = UIScreen.main.bounds.width - 32
-}
-
-// TODO: - 전역변수 추후 삭제. RxSwift 사용 시 수정
-
-let components = Components()
-
 class DetailViewController: UIViewController, UIScrollViewDelegate {
 
     // MARK: - Property
     
+    let screenWidth = UIScreen.main.bounds.width - 32
+    
     var naviTitle = "화장실"
+    var images = ["Test01","Test02","Test03","Test04"]
     
     // MARK: - View
     
-    private let scrollView: UIScrollView = {
+    lazy var scrollView: UIScrollView = {
         
         // TODO: - 이미지 갯수만큼 스크롤 가능. 데이터 반영 시 Images를 수정하여 데이터 갯수만큼 지정.
         
         $0.contentSize = CGSize(
-            width: Int(components.screenWidth) * components.images.count,
-            height: Int(components.screenWidth) / 4 * 3
+            width: Int(screenWidth) * images.count,
+            height: Int(screenWidth) / 4 * 3
         )
         $0.isScrollEnabled = true
         $0.showsHorizontalScrollIndicator = false
@@ -43,11 +34,11 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIScrollView())
     
-    private let pageControl: UIPageControl = {
+    lazy var pageControl: UIPageControl = {
        
         // TODO: - 서버연결 시 images를 데이터로 변경해야함.
         
-        $0.numberOfPages = components.images.count
+        $0.numberOfPages = images.count
         $0.currentPage = 0
         $0.pageIndicatorTintColor = UIColor.lightGray
         $0.currentPageIndicatorTintColor = UIColor.black
@@ -55,10 +46,10 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIPageControl())
     
-    private let descriptionView: UIScrollView = {
+    lazy var descriptionView: UIScrollView = {
         $0.contentSize = CGSize(
-            width: components.screenWidth,
-            height: components.screenWidth / 5 * 2
+            width: screenWidth,
+            height: screenWidth / 5 * 2
         )
         $0.layer.cornerRadius = 16
         $0.backgroundColor = .lightGray
@@ -119,7 +110,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             paddingTop: 20,
             paddingLeft: 16,
             paddingRight: 16,
-            height: components.screenWidth / 5 * 2
+            height: screenWidth / 5 * 2
         )
         
         descriptionLBL.anchor(
@@ -154,11 +145,11 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        pageControl.currentPage = Int(scrollView.contentOffset.x / components.screenWidth)
+        pageControl.currentPage = Int(scrollView.contentOffset.x / screenWidth)
     }
     
     @objc func pageDidChange(sender: UIPageControl){
-        let offsetX = components.screenWidth * CGFloat(pageControl.currentPage)
+        let offsetX = screenWidth * CGFloat(pageControl.currentPage)
         scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
     }
     
@@ -183,7 +174,7 @@ extension DetailViewController {
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingLeft: 16,
             paddingRight: 16,
-            height: components.screenWidth / 4 * 3
+            height: screenWidth / 4 * 3
         )
         
         pageControl.anchor(
@@ -195,8 +186,8 @@ extension DetailViewController {
             paddingRight: 16
         )
         
-        for num in 0..<components.images.count {
-            addImageView(img: components.images[num], position: CGFloat(num))
+        for num in 0..<images.count {
+            addImageView(img: images[num], position: CGFloat(num))
         }
     }
     
@@ -207,10 +198,10 @@ extension DetailViewController {
         scrollView.addSubview(constructionImage)
         
         constructionImage.frame = CGRect(
-            x: components.screenWidth * position,
+            x: screenWidth * position,
             y: 0,
-            width: components.screenWidth,
-            height: components.screenWidth / 4 * 3
+            width: screenWidth,
+            height: screenWidth / 4 * 3
         )
     }
 }

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -13,12 +13,12 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     
     let screenWidth = UIScreen.main.bounds.width - 32
     
-    var naviTitle = "화장실"
+    private var naviTitle = "화장실"
     var images = ["Test01","Test02","Test03","Test04"]
     
     // MARK: - View
     
-    lazy var scrollView: UIScrollView = {
+    private lazy var scrollView: UIScrollView = {
         
         // TODO: - 이미지 갯수만큼 스크롤 가능. 데이터 반영 시 Images를 수정하여 데이터 갯수만큼 지정.
         
@@ -34,7 +34,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIScrollView())
     
-    lazy var pageControl: UIPageControl = {
+    private lazy var pageControl: UIPageControl = {
        
         // TODO: - 서버연결 시 images를 데이터로 변경해야함.
         
@@ -46,7 +46,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIPageControl())
     
-    lazy var descriptionView: UIScrollView = {
+    private lazy var descriptionView: UIScrollView = {
         $0.contentSize = CGSize(
             width: screenWidth,
             height: screenWidth / 5 * 2
@@ -148,7 +148,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         pageControl.currentPage = Int(scrollView.contentOffset.x / screenWidth)
     }
     
-    @objc func pageDidChange(sender: UIPageControl){
+    @objc private func pageDidChange(sender: UIPageControl){
         let offsetX = screenWidth * CGFloat(pageControl.currentPage)
         scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
     }
@@ -164,7 +164,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 // MARK: - configuratingScrollView
 
 extension DetailViewController {
-    func configuratingScrollView() {
+    private func configuratingScrollView() {
         view.addSubview(scrollView)
         view.addSubview(pageControl)
 
@@ -191,7 +191,7 @@ extension DetailViewController {
         }
     }
     
-    func addImageView(img: String, position: CGFloat) {
+    private func addImageView(img: String, position: CGFloat) {
         let constructionImage = UIImageView()
         constructionImage.image = UIImage(named: img)
         

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -13,12 +13,12 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     
     let screenWidth = UIScreen.main.bounds.width - 32
     
-    var naviTitle = "화장실"
+    private var naviTitle = "화장실"
     var images = ["Test01","Test02","Test03","Test04"]
     
     // MARK: - View
     
-    lazy var scrollView: UIScrollView = {
+    private lazy var scrollView: UIScrollView = {
         
         // TODO: - 이미지 갯수만큼 스크롤 가능. 데이터 반영 시 Images를 수정하여 데이터 갯수만큼 지정.
         
@@ -34,7 +34,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIScrollView())
     
-    lazy var pageControl: UIPageControl = {
+    private lazy var pageControl: UIPageControl = {
        
         // TODO: - 서버연결 시 images를 데이터로 변경해야함.
         
@@ -46,7 +46,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIPageControl())
     
-    lazy var descriptionView: UIScrollView = {
+    private lazy var descriptionView: UIScrollView = {
         $0.contentSize = CGSize(
             width: screenWidth,
             height: screenWidth / 5 * 2
@@ -148,7 +148,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         pageControl.currentPage = Int(scrollView.contentOffset.x / screenWidth)
     }
     
-    @objc func pageDidChange(sender: UIPageControl){
+    @objc private func pageDidChange(sender: UIPageControl){
         let offsetX = screenWidth * CGFloat(pageControl.currentPage)
         scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
     }
@@ -157,7 +157,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 // MARK: - configuratingScrollView
 
 extension DetailViewController {
-    func configuratingScrollView() {
+    private func configuratingScrollView() {
         view.addSubview(scrollView)
         view.addSubview(pageControl)
 
@@ -184,7 +184,7 @@ extension DetailViewController {
         }
     }
     
-    func addImageView(img: String, position: CGFloat) {
+    private func addImageView(img: String, position: CGFloat) {
         let constructionImage = UIImageView()
         constructionImage.image = UIImage(named: img)
         

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -7,33 +7,24 @@
 
 import UIKit
 
-struct Components {
-    
-    // TODO: - 서버연결 시 TestImage 삭제
-    
-    var images = ["Test01","Test02","Test03","Test04"]
-    let screenWidth = UIScreen.main.bounds.width - 32
-}
-
-// TODO: - 전역변수 추후 삭제. RxSwift 사용 시 수정
-
-let components = Components()
-
 class DetailViewController: UIViewController, UIScrollViewDelegate {
 
     // MARK: - Property
     
+    let screenWidth = UIScreen.main.bounds.width - 32
+    
     var naviTitle = "화장실"
+    var images = ["Test01","Test02","Test03","Test04"]
     
     // MARK: - View
     
-    private let scrollView: UIScrollView = {
+    lazy var scrollView: UIScrollView = {
         
         // TODO: - 이미지 갯수만큼 스크롤 가능. 데이터 반영 시 Images를 수정하여 데이터 갯수만큼 지정.
         
         $0.contentSize = CGSize(
-            width: Int(components.screenWidth) * components.images.count,
-            height: Int(components.screenWidth) / 4 * 3
+            width: Int(screenWidth) * images.count,
+            height: Int(screenWidth) / 4 * 3
         )
         $0.isScrollEnabled = true
         $0.showsHorizontalScrollIndicator = false
@@ -43,11 +34,11 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIScrollView())
     
-    private let pageControl: UIPageControl = {
+    lazy var pageControl: UIPageControl = {
        
         // TODO: - 서버연결 시 images를 데이터로 변경해야함.
         
-        $0.numberOfPages = components.images.count
+        $0.numberOfPages = images.count
         $0.currentPage = 0
         $0.pageIndicatorTintColor = UIColor.lightGray
         $0.currentPageIndicatorTintColor = UIColor.black
@@ -55,10 +46,10 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         return $0
     }(UIPageControl())
     
-    private let descriptionView: UIScrollView = {
+    lazy var descriptionView: UIScrollView = {
         $0.contentSize = CGSize(
-            width: components.screenWidth,
-            height: components.screenWidth / 5 * 2
+            width: screenWidth,
+            height: screenWidth / 5 * 2
         )
         $0.layer.cornerRadius = 16
         $0.backgroundColor = .lightGray
@@ -119,7 +110,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             paddingTop: 20,
             paddingLeft: 16,
             paddingRight: 16,
-            height: components.screenWidth / 5 * 2
+            height: screenWidth / 5 * 2
         )
         
         descriptionLBL.anchor(
@@ -154,11 +145,11 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        pageControl.currentPage = Int(scrollView.contentOffset.x / components.screenWidth)
+        pageControl.currentPage = Int(scrollView.contentOffset.x / screenWidth)
     }
     
     @objc func pageDidChange(sender: UIPageControl){
-        let offsetX = components.screenWidth * CGFloat(pageControl.currentPage)
+        let offsetX = screenWidth * CGFloat(pageControl.currentPage)
         scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
     }
 }
@@ -176,7 +167,7 @@ extension DetailViewController {
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingLeft: 16,
             paddingRight: 16,
-            height: components.screenWidth / 4 * 3
+            height: screenWidth / 4 * 3
         )
         
         pageControl.anchor(
@@ -188,8 +179,8 @@ extension DetailViewController {
             paddingRight: 16
         )
         
-        for num in 0..<components.images.count {
-            addImageView(img: components.images[num], position: CGFloat(num))
+        for num in 0..<images.count {
+            addImageView(img: images[num], position: CGFloat(num))
         }
     }
     
@@ -200,10 +191,10 @@ extension DetailViewController {
         scrollView.addSubview(constructionImage)
         
         constructionImage.frame = CGRect(
-            x: components.screenWidth * position,
+            x: screenWidth * position,
             y: 0,
-            width: components.screenWidth,
-            height: components.screenWidth / 4 * 3
+            width: screenWidth,
+            height: screenWidth / 4 * 3
         )
     }
 }

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -11,7 +11,7 @@ class WorkingHistoryViewController: UIViewController {
 
     // MARK: - View
     
-    private let writingBtn: UIButton = {
+    private let writingButton: UIButton = {
         $0.backgroundColor = .yellow
         $0.setTitle("시공상황 작성하기", for: .normal)
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
@@ -47,11 +47,13 @@ class WorkingHistoryViewController: UIViewController {
         
         workingHistoryView.register(WorkingHistoryViewHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: WorkingHistoryViewHeader.identifier)
         workingHistoryView.register(WorkingHistoryViewCell.self, forCellWithReuseIdentifier: WorkingHistoryViewCell.identifier)
+        
+        writingButton.addTarget(self, action: #selector(tapWritingButton), for: .touchDown)
     }
     
     private func layout() {
         view.addSubview(workingHistoryView)
-        view.addSubview(writingBtn)
+        view.addSubview(writingButton)
         
         workingHistoryView.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
@@ -60,7 +62,7 @@ class WorkingHistoryViewController: UIViewController {
             right: view.safeAreaLayoutGuide.rightAnchor
         )
 
-        writingBtn.anchor(
+        writingButton.anchor(
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
@@ -68,6 +70,14 @@ class WorkingHistoryViewController: UIViewController {
             paddingRight: 16,
             height: 50
         )
+    }
+    
+    // TODO: - postingCategoryView를 FullScreen모달로 띄우는 기능. 추후 수정
+    
+    @objc func tapWritingButton() {
+        let postingCategoryView = ViewController()
+        postingCategoryView.modalPresentationStyle = .fullScreen
+        present(postingCategoryView, animated:  true, completion: nil)
     }
 }
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 전역변수였던 Components를 삭제하여 메모리누수를 제거하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- lazy variable을 이용한 코드 리팩토링

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- lazy 변수는 항상 메모리관리 측면에서 유리할까요?

## Reference 🔗
- lazy프로퍼티에 대한 참고자료1: https://dev-dmsgk.tistory.com/35
- lazy프로퍼티에 대한 참고자료2: https://hyunndyblog.tistory.com/155
  - lazy프로퍼티는 var에만 사용 가능.
    - let은 초기화 전에 값을 가져야하기 때문에 사용할 수 없다.
    - lazy는 초기화되기 전까지 값이 계산되지 않는다. (즉, 초기화가 되어야 값을 가짐. let을 사용할 수 없는 이유.)
    - 초기화될 때 불려진다는 의미에서 메모리관리 측면에서 유리하다.
  - lazy 프로퍼티 내에 self를 붙임으로써 순환참조가 일어나는 것을 방지할 수 있다.
  - 일반적으로 초기값을 유지한다. 
    - 다만, 멀티스레드 환경에서 해당 프로퍼티에 동시 접근하는 경우 여러 번 초기화될 수 있다.
  - ViewDidLoad 내 코드가 복잡해지는 경우를 방지할 수 있다.

## Close Issues 🔒 (닫을 Issue)
Close #39.
