### PR TITLE
[Design] 방 생성 뷰(RoomCreationView) 레이아웃

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */; };
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
+		98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */; };
 		98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */; };
 		98C0D06428FCE99300E0E439 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06328FCE99300E0E439 /* JSON.swift */; };
 		98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06628FCE9DC00E0E439 /* Model.swift */; };
@@ -50,6 +51,7 @@
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingCategoryViewController.swift; sourceTree = "<group>"; };
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
+		98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationViewContoller.swift; sourceTree = "<group>"; };
 		98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayout+.swift"; sourceTree = "<group>"; };
 		98C0D06328FCE99300E0E439 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		98C0D06628FCE9DC00E0E439 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
@@ -111,6 +113,14 @@
 			path = DetailView;
 			sourceTree = "<group>";
 		};
+		98366F8B29019A3100E81E27 /* RoomCreationView */ = {
+			isa = PBXGroup;
+			children = (
+				98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */,
+			);
+			path = RoomCreationView;
+			sourceTree = "<group>";
+		};
 		98C0D05D28FCE8C300E0E439 /* Global */ = {
 			isa = PBXGroup;
 			children = (
@@ -143,6 +153,7 @@
 				43C2111028FCFB3800E8F6DD /* CategoryCell.swift */,
 				43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */,
 				4369690B28FE422100DEA89F /* PostingImageViewController.swift */,
+				98366F8B29019A3100E81E27 /* RoomCreationView */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -274,6 +285,7 @@
 				26E3748228FCDC0000997DA7 /* AppDelegate.swift in Sources */,
 				43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */,
 				26E3748428FCDC0000997DA7 /* SceneDelegate.swift in Sources */,
+				98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */,
 				26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */,
 				98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */,
 				26E3749628FCF56400997DA7 /* RoomListViewController.swift in Sources */,

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -96,7 +96,7 @@ class RoomCreationViewController: UIViewController {
 
     private var warrantyText: UILabel = {
         $0.text = "0개월"
-        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         return $0
     }(UILabel())
     

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -11,7 +11,7 @@ class RoomCreationViewController: UIViewController {
     
     // MARK: - Property
     
-    private var warrantyCount = 0
+    private lazy var warrantyCount = 0
     
     // MARK: - View
     

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -22,13 +22,14 @@ class RoomCreationViewController: UIViewController {
     private let customerTitle: UILabel = {
         $0.text = "고객명/주소"
         $0.textAlignment = .left
-        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.textColor = .black
         return $0
     }(UILabel())
     
     private let customerTextField: UITextField = {
         $0.placeholder = "고객의 별칭을 작성해주세요."
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         return $0
     }(UITextField())
     
@@ -46,7 +47,7 @@ class RoomCreationViewController: UIViewController {
     private let startDateLabel: UILabel = {
         $0.text = "시공일"
         $0.textAlignment = .left
-        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.textColor = .black
         return $0
     }(UILabel())
@@ -67,7 +68,7 @@ class RoomCreationViewController: UIViewController {
     private let endDateLabel: UILabel = {
         $0.text = "준공일"
         $0.textAlignment = .left
-        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.textColor = .black
         return $0
     }(UILabel())
@@ -88,14 +89,14 @@ class RoomCreationViewController: UIViewController {
     private let warrantyLabel: UILabel = {
         $0.text = "AS기간"
         $0.textAlignment = .left
-        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.textColor = .black
         return $0
     }(UILabel())
 
     private var warrantyText: UILabel = {
         $0.text = "0개월"
-        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         return $0
     }(UILabel())
     
@@ -176,7 +177,7 @@ class RoomCreationViewController: UIViewController {
             left: uiView.leftAnchor,
             bottom: textUnderLine.topAnchor,
             right: uiView.rightAnchor,
-            paddingLeft: 2,
+            paddingLeft: 4,
             paddingBottom: 4
         )
         

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -1,0 +1,191 @@
+//
+//  RoomCreationViewContoller.swift
+//  Samsam
+//
+//  Created by 지준용 on 2022/10/21.
+//
+
+import UIKit
+
+class RoomCreationViewController: UIViewController {
+
+    // MARK: - View
+    
+    private let customerTitle: UILabel = {
+        $0.text = "고객명/주소"
+        $0.textAlignment = .left
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.textColor = .black
+        return $0
+    }(UILabel())
+    
+    private let customerTextField: UITextField = {
+        $0.placeholder = "고객의 별칭을 작성해주세요."
+        return $0
+    }(UITextField())
+    
+    private let textUnderLine: UIView = {
+        $0.backgroundColor = .black
+        $0.setHeight(height: 1)
+        return $0
+    }(UITextField())
+    
+    private let startDateHstack: UIStackView = {
+        return $0
+    }(UIStackView())
+    
+    private let startDateLabel: UILabel = {
+        $0.text = "시공일"
+        $0.textAlignment = .left
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.textColor = .black
+        return $0
+    }(UILabel())
+    
+    private var startDate: UITextView = {
+        $0.textColor = .black
+        return $0
+    }(UITextView())
+    
+    private let endDateHstack: UIStackView = {
+        return $0
+    }(UIStackView())
+    
+    private let endDateLabel: UILabel = {
+        $0.text = "준공일"
+        $0.textAlignment = .left
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.textColor = .black
+        return $0
+    }(UILabel())
+    
+    private var endDate: UITextView = {
+        $0.textColor = .black
+        return $0
+    }(UITextView())
+    
+    private let warrantyHstack: UIStackView = {
+        return $0
+    }(UIStackView())
+    
+    private let warrantyLabel: UILabel = {
+        $0.text = "AS기간"
+        $0.textAlignment = .left
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.textColor = .black
+        return $0
+    }(UILabel())
+    
+    private var warrantyText: UILabel = {
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.backgroundColor = .black
+        return $0
+    }(UILabel())
+    
+    private let warrantyStepper: UIStepper = {
+        $0.maximumValue = 60
+        $0.minimumValue = 0
+        $0.wraps = true // 무슨 기능일까?
+        $0.autorepeat = true
+        return $0
+    }(UIStepper())
+    
+    
+    private let nextButton: UIButton = {
+        $0.setTitle("다음", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.backgroundColor = .yellow
+        return $0
+    }(UIButton())
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        layout()
+    }
+    
+    private func layout() {
+        view.addSubview(customerTitle)
+        view.addSubview(customerTextField)
+        view.addSubview(textUnderLine)
+        view.addSubview(startDateHstack)
+        startDateHstack.addArrangedSubview(startDateLabel)
+        startDateHstack.addArrangedSubview(startDate)
+        view.addSubview(endDateHstack)
+        endDateHstack.addArrangedSubview(endDateLabel)
+        endDateHstack.addArrangedSubview(endDate)
+        view.addSubview(warrantyHstack)
+        warrantyHstack.addArrangedSubview(warrantyLabel)
+        warrantyHstack.addArrangedSubview(warrantyText)
+        warrantyHstack.addArrangedSubview(warrantyStepper)
+        view.addSubview(nextButton)
+        
+        
+        customerTitle.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: customerTextField.topAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 40,
+            paddingLeft: 16,
+            paddingBottom: 16,
+            paddingRight: 16
+        )
+        
+        customerTextField.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: startDateHstack.topAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 18,
+            paddingBottom: 20,
+            paddingRight: 16
+        )
+        
+        textUnderLine.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: startDateHstack.topAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 16,
+            paddingBottom: 20,
+            paddingRight: 16
+        )
+        
+        startDateHstack.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: endDateHstack.topAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 16,
+            paddingBottom: 20,
+            paddingRight: 16
+        )
+
+        endDateHstack.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: warrantyHstack.topAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 16,
+            paddingBottom: 20,
+            paddingRight: 16
+        )
+        
+        warrantyHstack.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 16,
+            paddingRight: 16
+        )
+        
+        nextButton.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 16,
+            paddingBottom: 16,
+            paddingRight: 16,
+            height: 50
+        )
+    }
+}
+

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -11,7 +11,7 @@ class RoomCreationViewController: UIViewController {
     
     // MARK: - Property
     
-    private lazy var warrantyCount = 0
+    private lazy var warrantyCount = 12
     
     // MARK: - View
     
@@ -95,12 +95,13 @@ class RoomCreationViewController: UIViewController {
     }(UILabel())
 
     private var warrantyText: UILabel = {
-        $0.text = "0개월"
+        $0.text = "12개월"
         $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         return $0
     }(UILabel())
     
     private let warrantyStepper: UIStepper = {
+        $0.value = 12
         $0.maximumValue = 24
         $0.minimumValue = 0
         $0.wraps = true

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class RoomCreationViewController: UIViewController {
     
+    // MARK: - Property
+    
     private var warrantyCount = 0
     
     // MARK: - View
@@ -83,7 +85,7 @@ class RoomCreationViewController: UIViewController {
         $0.textColor = .black
         return $0
     }(UILabel())
-//
+
     private var warrantyText: UILabel = {
         $0.text = "0개월"
         $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
@@ -110,13 +112,15 @@ class RoomCreationViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
         
         attribute()
         layout()
     }
     
+    // MARK: - Method
+    
     private func attribute() {
+        view.backgroundColor = .white
         setNavigationbar()
         nextButton.addTarget(self, action: #selector(tapNextButton), for: .touchUpInside)
     }
@@ -136,7 +140,6 @@ class RoomCreationViewController: UIViewController {
         warrantyHstack.addArrangedSubview(warrantyText)
         warrantyHstack.addArrangedSubview(warrantyStepper)
         view.addSubview(nextButton)
-        
         
         customerTitle.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -129,16 +129,20 @@ class RoomCreationViewController: UIViewController {
         view.addSubview(customerTitle)
         view.addSubview(customerTextField)
         view.addSubview(textUnderLine)
+        
         view.addSubview(startDateHstack)
         startDateHstack.addArrangedSubview(startDateLabel)
         startDateHstack.addArrangedSubview(startDate)
+        
         view.addSubview(endDateHstack)
         endDateHstack.addArrangedSubview(endDateLabel)
         endDateHstack.addArrangedSubview(endDate)
+        
         view.addSubview(warrantyHstack)
         warrantyHstack.addArrangedSubview(warrantyLabel)
         warrantyHstack.addArrangedSubview(warrantyText)
         warrantyHstack.addArrangedSubview(warrantyStepper)
+        
         view.addSubview(nextButton)
         
         customerTitle.anchor(

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -39,6 +39,7 @@ class RoomCreationViewController: UIViewController {
     }(UITextField())
     
     private let startDateHstack: UIStackView = {
+        $0.axis = .horizontal
         return $0
     }(UIStackView())
     
@@ -59,6 +60,7 @@ class RoomCreationViewController: UIViewController {
     }(UIDatePicker())
     
     private let endDateHstack: UIStackView = {
+        $0.axis = .horizontal
         return $0
     }(UIStackView())
     
@@ -79,6 +81,7 @@ class RoomCreationViewController: UIViewController {
     }(UIDatePicker())
     
     private let warrantyHstack: UIStackView = {
+        $0.axis = .horizontal
         return $0
     }(UIStackView())
     

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -15,6 +15,10 @@ class RoomCreationViewController: UIViewController {
     
     // MARK: - View
     
+    private let uiView: UIView = {
+        return $0
+    }(UIView())
+    
     private let customerTitle: UILabel = {
         $0.text = "고객명/주소"
         $0.textAlignment = .left
@@ -126,29 +130,30 @@ class RoomCreationViewController: UIViewController {
     }
     
     private func layout() {
-        view.addSubview(customerTitle)
-        view.addSubview(customerTextField)
-        view.addSubview(textUnderLine)
+        view.addSubview(uiView)
+        uiView.addSubview(customerTitle)
+        uiView.addSubview(customerTextField)
+        uiView.addSubview(textUnderLine)
         
-        view.addSubview(startDateHstack)
+        uiView.addSubview(startDateHstack)
         startDateHstack.addArrangedSubview(startDateLabel)
         startDateHstack.addArrangedSubview(startDate)
         
-        view.addSubview(endDateHstack)
+        uiView.addSubview(endDateHstack)
         endDateHstack.addArrangedSubview(endDateLabel)
         endDateHstack.addArrangedSubview(endDate)
         
-        view.addSubview(warrantyHstack)
+        uiView.addSubview(warrantyHstack)
         warrantyHstack.addArrangedSubview(warrantyLabel)
         warrantyHstack.addArrangedSubview(warrantyText)
         warrantyHstack.addArrangedSubview(warrantyStepper)
         
-        view.addSubview(nextButton)
+        uiView.addSubview(nextButton)
         
-        customerTitle.anchor(
+        uiView.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
-            bottom: customerTextField.topAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingTop: 40,
             paddingLeft: 16,
@@ -156,47 +161,46 @@ class RoomCreationViewController: UIViewController {
             paddingRight: 16
         )
         
+        customerTitle.anchor(
+            top: uiView.topAnchor,
+            left: uiView.leftAnchor,
+            bottom: customerTextField.topAnchor,
+            right: uiView.rightAnchor,
+            paddingBottom: 16
+        )
+        
         customerTextField.anchor(
-            left: view.safeAreaLayoutGuide.leftAnchor,
-            bottom: startDateHstack.topAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 18,
-            paddingBottom: 20,
-            paddingRight: 16
+            left: uiView.leftAnchor,
+            bottom: textUnderLine.topAnchor,
+            right: uiView.rightAnchor,
+            paddingLeft: 2,
+            paddingBottom: 4
         )
         
         textUnderLine.anchor(
-            left: view.safeAreaLayoutGuide.leftAnchor,
+            left: uiView.leftAnchor,
             bottom: startDateHstack.topAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 16,
-            paddingBottom: 20,
-            paddingRight: 16
+            right: uiView.rightAnchor,
+            paddingBottom: 20
         )
         
         startDateHstack.anchor(
-            left: view.safeAreaLayoutGuide.leftAnchor,
+            left: uiView.leftAnchor,
             bottom: endDateHstack.topAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 16,
-            paddingBottom: 20,
-            paddingRight: 16
+            right: uiView.rightAnchor,
+            paddingBottom: 20
         )
 
         endDateHstack.anchor(
-            left: view.safeAreaLayoutGuide.leftAnchor,
+            left: uiView.leftAnchor,
             bottom: warrantyHstack.topAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 16,
-            paddingBottom: 20,
-            paddingRight: 16
+            right: uiView.rightAnchor,
+            paddingBottom: 20
         )
         
         warrantyHstack.anchor(
-            left: view.safeAreaLayoutGuide.leftAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 16,
-            paddingRight: 16
+            left: uiView.leftAnchor,
+            right: uiView.rightAnchor
         )
         
         warrantyText.anchor(
@@ -205,12 +209,9 @@ class RoomCreationViewController: UIViewController {
         )
 
         nextButton.anchor(
-            left: view.safeAreaLayoutGuide.leftAnchor,
-            bottom: view.safeAreaLayoutGuide.bottomAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 16,
-            paddingBottom: 16,
-            paddingRight: 16,
+            left: uiView.leftAnchor,
+            bottom: uiView.bottomAnchor,
+            right: uiView.rightAnchor,
             height: 50
         )
     }
@@ -236,4 +237,3 @@ class RoomCreationViewController: UIViewController {
         navigationController?.pushViewController(VC, animated: true)
     }
 }
-

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -95,7 +95,7 @@ class RoomCreationViewController: UIViewController {
         $0.minimumValue = 0
         $0.wraps = true
         $0.autorepeat = true
-//        $0.addTarget(self, action: #selector(tapStepper), for: .touchUpInside)
+        $0.addTarget(self, action: #selector(tapStepper), for: .touchUpInside)
         return $0
     }(UIStepper())
     
@@ -118,7 +118,7 @@ class RoomCreationViewController: UIViewController {
     
     private func attribute() {
         setNavigationbar()
-        warrantyStepper.addTarget(self, action: #selector(tapStepper), for: .touchUpInside)
+        nextButton.addTarget(self, action: #selector(tapNextButton), for: .touchUpInside)
     }
     
     private func layout() {
@@ -220,6 +220,13 @@ class RoomCreationViewController: UIViewController {
     @objc private func tapStepper() {
         warrantyCount = Int(warrantyStepper.value)
         warrantyText.text = "\(warrantyCount)개월"
+    }
+    
+    // TODO: - 방생성카테고리 뷰로 수정 예정.
+    
+    @objc private func tapNextButton() {
+        let VC = ViewController()
+        navigationController?.pushViewController(VC, animated: true)
     }
 }
 

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 class RoomCreationViewController: UIViewController {
-
+    
+    private var warrantyCount = 0
+    
     // MARK: - View
     
     private let customerTitle: UILabel = {
@@ -42,10 +44,13 @@ class RoomCreationViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private var startDate: UITextView = {
-        $0.textColor = .black
+    private var startDate: UIDatePicker = {
+        $0.datePickerMode = .date
+        $0.locale = Locale(identifier: "ko-KR")
+        $0.timeZone = .autoupdatingCurrent
+        $0.preferredDatePickerStyle = .compact
         return $0
-    }(UITextView())
+    }(UIDatePicker())
     
     private let endDateHstack: UIStackView = {
         return $0
@@ -59,10 +64,13 @@ class RoomCreationViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private var endDate: UITextView = {
-        $0.textColor = .black
+    private var endDate: UIDatePicker = {
+        $0.datePickerMode = .date
+        $0.locale = Locale(identifier: "ko-KR")
+        $0.timeZone = .autoupdatingCurrent
+        $0.preferredDatePickerStyle = .compact
         return $0
-    }(UITextView())
+    }(UIDatePicker())
     
     private let warrantyHstack: UIStackView = {
         return $0
@@ -75,21 +83,21 @@ class RoomCreationViewController: UIViewController {
         $0.textColor = .black
         return $0
     }(UILabel())
-    
+//
     private var warrantyText: UILabel = {
+        $0.text = "0개월"
         $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
-        $0.backgroundColor = .black
         return $0
     }(UILabel())
     
     private let warrantyStepper: UIStepper = {
-        $0.maximumValue = 60
+        $0.maximumValue = 24
         $0.minimumValue = 0
-        $0.wraps = true // 무슨 기능일까?
+        $0.wraps = true
         $0.autorepeat = true
+//        $0.addTarget(self, action: #selector(tapStepper), for: .touchUpInside)
         return $0
     }(UIStepper())
-    
     
     private let nextButton: UIButton = {
         $0.setTitle("다음", for: .normal)
@@ -103,7 +111,14 @@ class RoomCreationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        
+        attribute()
         layout()
+    }
+    
+    private func attribute() {
+        setNavigationbar()
+        warrantyStepper.addTarget(self, action: #selector(tapStepper), for: .touchUpInside)
     }
     
     private func layout() {
@@ -177,6 +192,11 @@ class RoomCreationViewController: UIViewController {
             paddingRight: 16
         )
         
+        warrantyText.anchor(
+            right: warrantyStepper.leftAnchor,
+            paddingRight: 10
+        )
+
         nextButton.anchor(
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
@@ -186,6 +206,20 @@ class RoomCreationViewController: UIViewController {
             paddingRight: 16,
             height: 50
         )
+    }
+    
+    private func setNavigationbar() {
+        let appearance = UINavigationBarAppearance()
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.topItem?.title = "방 생성"
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+    
+    @objc private func tapStepper() {
+        warrantyCount = Int(warrantyStepper.value)
+        warrantyText.text = "\(warrantyCount)개월"
     }
 }
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 방생성뷰 레이아웃을 만들기 위함.

## Key Changes 🔥 (주요 구현/변경 사항)
- DatePicker
- Stepper
- navigation

## ToDo 📆 (남은 작업)
- [ ] DatePicker 시공일 기준으로, 준공일이 시공일 이전을 선택할 수 없도록 하는 것.
- [ ] DatePicker popup스타일이 아닌, 아코디언 스타일로 변경

## ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/98405970/197232427-f9cbd866-57c4-4be9-b5de-c78ec1035c83.mp4

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- stepper를 0개월일 때, 또는 24개월일 때 - 또는 + 클릭 시 0에서 24로, 24에서 0으로 넘어가지 않도록 하는 게 좋을까요?
- 아니면 넘어갈 수 있도록 하는 게 좋을까요?

## Reference 🔗
- Stepper 참고자료: https://leeari95.tistory.com/58
- DatePicker 참고자료: https://kasroid.github.io/posts/ios/20201030-uikit-date-picker/
- autoUpdatingCurrent 참고자료:  https://developer.apple.com/documentation/foundation/timezone/2292819-autoupdatingcurrent

## Close Issues 🔒 (닫을 Issue)
Close #43 .
