### PR TITLE
[Design] 시공내역뷰 타입 및 네비게이션 추가

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -18,10 +18,10 @@
 		26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */; };
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
-		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */; };
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
+		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */; };
 		98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */; };
 		98C0D06428FCE99300E0E439 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06328FCE99300E0E439 /* JSON.swift */; };
@@ -47,10 +47,10 @@
 		26E3749D28FE95D100997DA7 /* Samsam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Samsam.entitlements; sourceTree = "<group>"; };
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
-		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingCategoryViewController.swift; sourceTree = "<group>"; };
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
+		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationViewContoller.swift; sourceTree = "<group>"; };
 		98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayout+.swift"; sourceTree = "<group>"; };
 		98C0D06328FCE99300E0E439 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
@@ -144,8 +144,8 @@
 			children = (
 				26E3748528FCDC0000997DA7 /* ViewController.swift */,
 				26E3749528FCF56400997DA7 /* RoomListViewController.swift */,
-				26E3749728FD2D0700997DA7 /* RoomListCell.swift */,
 				26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */,
+				26E3749728FD2D0700997DA7 /* RoomListCell.swift */,
 				98C0D06D28FCF46A00E0E439 /* WorkingHistoryView */,
 				26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */,
 				26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */,

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */; };
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
+		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
+		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */; };
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
@@ -49,6 +51,8 @@
 		26E3749D28FE95D100997DA7 /* Samsam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Samsam.entitlements; sourceTree = "<group>"; };
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
+		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
+		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingCategoryViewController.swift; sourceTree = "<group>"; };
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
@@ -159,6 +163,7 @@
 				4369690B28FE422100DEA89F /* PostingImageViewController.swift */,
 				98366F8B29019A3100E81E27 /* RoomCreationView */,
 				43956D2B28FF9F0100DD996F /* PostingWritingView.swift */,
+				4386FB012901353B00314936 /* RoomCategoryViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -292,6 +297,7 @@
 				43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */,
 				26E3748428FCDC0000997DA7 /* SceneDelegate.swift in Sources */,
 				98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */,
+				4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */,
 				26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */,
 				98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */,
 				26E3749628FCF56400997DA7 /* RoomListViewController.swift in Sources */,

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -18,9 +18,9 @@
 		26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */; };
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
-		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
-		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
+		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
+		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
 		43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */; };
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
 		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
@@ -51,9 +51,9 @@
 		26E3749D28FE95D100997DA7 /* Samsam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Samsam.entitlements; sourceTree = "<group>"; };
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
-		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
-		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
+		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
+		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
 		43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingCategoryViewController.swift; sourceTree = "<group>"; };
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
@@ -163,6 +163,7 @@
 				4369690B28FE422100DEA89F /* PostingImageViewController.swift */,
 				98366F8B29019A3100E81E27 /* RoomCreationView */,
 				43956D2B28FF9F0100DD996F /* PostingWritingView.swift */,
+				43BD591929028BD70063EB4F /* RoomCodeViewController.swift */,
 				4386FB012901353B00314936 /* RoomCategoryViewController.swift */,
 			);
 			path = ViewController;
@@ -298,6 +299,7 @@
 				26E3748428FCDC0000997DA7 /* SceneDelegate.swift in Sources */,
 				98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */,
 				4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */,
+				43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */,
 				26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */,
 				98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */,
 				26E3749628FCF56400997DA7 /* RoomListViewController.swift in Sources */,

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -163,8 +163,8 @@
 				4369690B28FE422100DEA89F /* PostingImageViewController.swift */,
 				98366F8B29019A3100E81E27 /* RoomCreationView */,
 				43956D2B28FF9F0100DD996F /* PostingWritingView.swift */,
-				43BD591929028BD70063EB4F /* RoomCodeViewController.swift */,
 				4386FB012901353B00314936 /* RoomCategoryViewController.swift */,
+				43BD591929028BD70063EB4F /* RoomCodeViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -19,6 +19,16 @@
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
 		26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */; };
+		26FEC1D92902E6F2006C410B /* CategoryEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1CF2902E6F2006C410B /* CategoryEntity+CoreDataClass.swift */; };
+		26FEC1DA2902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D02902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift */; };
+		26FEC1DB2902E6F2006C410B /* PostingEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D12902E6F2006C410B /* PostingEntity+CoreDataClass.swift */; };
+		26FEC1DC2902E6F2006C410B /* PostingEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D22902E6F2006C410B /* PostingEntity+CoreDataProperties.swift */; };
+		26FEC1DD2902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D32902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift */; };
+		26FEC1DE2902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D42902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift */; };
+		26FEC1DF2902E6F2006C410B /* PhotoEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D52902E6F2006C410B /* PhotoEntity+CoreDataClass.swift */; };
+		26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */; };
+		26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */; };
+		26FEC1E22902E6F2006C410B /* RoomEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
 		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
@@ -53,6 +63,16 @@
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
 		26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DataTable.xcdatamodel; sourceTree = "<group>"; };
+		26FEC1CF2902E6F2006C410B /* CategoryEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D02902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D12902E6F2006C410B /* PostingEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostingEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D22902E6F2006C410B /* PostingEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostingEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D32902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkingStatusEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D42902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkingStatusEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D52902E6F2006C410B /* PhotoEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotoEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotoEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
 		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
@@ -119,6 +139,16 @@
 		26FEC1BA2902D87E006C410B /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				26FEC1CF2902E6F2006C410B /* CategoryEntity+CoreDataClass.swift */,
+				26FEC1D02902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift */,
+				26FEC1D12902E6F2006C410B /* PostingEntity+CoreDataClass.swift */,
+				26FEC1D22902E6F2006C410B /* PostingEntity+CoreDataProperties.swift */,
+				26FEC1D32902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift */,
+				26FEC1D42902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift */,
+				26FEC1D52902E6F2006C410B /* PhotoEntity+CoreDataClass.swift */,
+				26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */,
+				26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */,
+				26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */,
 				26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */,
 			);
 			path = CoreData;
@@ -294,30 +324,40 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26FEC1DB2902E6F2006C410B /* PostingEntity+CoreDataClass.swift in Sources */,
 				26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */,
 				980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */,
 				26E3748628FCDC0000997DA7 /* ViewController.swift in Sources */,
 				98C0D06C28FCF46500E0E439 /* WorkingHistoryViewController.swift in Sources */,
+				26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */,
 				98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */,
 				98C2448B28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift in Sources */,
 				98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */,
 				26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */,
 				26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */,
 				98C0D06428FCE99300E0E439 /* JSON.swift in Sources */,
+				26FEC1DA2902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift in Sources */,
+				26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */,
 				98C0D06A28FCEA4900E0E439 /* ImagePicker.swift in Sources */,
 				43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */,
+				26FEC1DC2902E6F2006C410B /* PostingEntity+CoreDataProperties.swift in Sources */,
 				26E3748228FCDC0000997DA7 /* AppDelegate.swift in Sources */,
 				43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */,
+				26FEC1DE2902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift in Sources */,
 				26E3748428FCDC0000997DA7 /* SceneDelegate.swift in Sources */,
 				98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */,
 				4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */,
 				43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */,
+				26FEC1DD2902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift in Sources */,
 				26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */,
 				98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */,
 				26E3749628FCF56400997DA7 /* RoomListViewController.swift in Sources */,
 				26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */,
 				43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */,
+				26FEC1D92902E6F2006C410B /* CategoryEntity+CoreDataClass.swift in Sources */,
 				4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */,
+				26FEC1DF2902E6F2006C410B /* PhotoEntity+CoreDataClass.swift in Sources */,
+				26FEC1E22902E6F2006C410B /* RoomEntity+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */; };
 		26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */; };
 		26FEC1E22902E6F2006C410B /* RoomEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */; };
+		26FEC1E4290466F2006C410B /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1E3290466F2006C410B /* CoreDataManager.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
 		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
@@ -73,6 +74,7 @@
 		26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotoEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1E3290466F2006C410B /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
 		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */,
 				26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */,
 				26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */,
+				26FEC1E3290466F2006C410B /* CoreDataManager.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -335,6 +338,7 @@
 				98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */,
 				26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */,
 				26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */,
+				26FEC1E4290466F2006C410B /* CoreDataManager.swift in Sources */,
 				98C0D06428FCE99300E0E439 /* JSON.swift in Sources */,
 				26FEC1DA2902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift in Sources */,
 				26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */,

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */; };
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
+		26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
 		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
@@ -51,6 +52,7 @@
 		26E3749D28FE95D100997DA7 /* Samsam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Samsam.entitlements; sourceTree = "<group>"; };
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
+		26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DataTable.xcdatamodel; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
 		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				26E3749D28FE95D100997DA7 /* Samsam.entitlements */,
+				26FEC1BA2902D87E006C410B /* CoreData */,
 				98C0D05D28FCE8C300E0E439 /* Global */,
 				98C0D06128FCE8FA00E0E439 /* ViewController */,
 				98C0D06528FCE9C700E0E439 /* Model */,
@@ -111,6 +114,14 @@
 				26E3748F28FCDC0100997DA7 /* Info.plist */,
 			);
 			path = Samsam;
+			sourceTree = "<group>";
+		};
+		26FEC1BA2902D87E006C410B /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */,
+			);
+			path = CoreData;
 			sourceTree = "<group>";
 		};
 		980D900C28FE6705003CC2DA /* DetailView */ = {
@@ -291,6 +302,7 @@
 				98C2448B28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift in Sources */,
 				98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */,
 				26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */,
+				26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */,
 				98C0D06428FCE99300E0E439 /* JSON.swift in Sources */,
 				98C0D06A28FCEA4900E0E439 /* ImagePicker.swift in Sources */,
 				43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */,
@@ -531,6 +543,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */,
+			);
+			currentVersion = 26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */;
+			path = DataTable.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 26E3747628FCDC0000997DA7 /* Project object */;
 }

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
 		98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */; };
 		43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43956D2B28FF9F0100DD996F /* PostingWritingView.swift */; };
+		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */; };
 		98C0D06428FCE99300E0E439 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06328FCE99300E0E439 /* JSON.swift */; };
 		98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06628FCE9DC00E0E439 /* Model.swift */; };
@@ -54,6 +55,7 @@
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationViewContoller.swift; sourceTree = "<group>"; };
 		43956D2B28FF9F0100DD996F /* PostingWritingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingWritingView.swift; sourceTree = "<group>"; };
+		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayout+.swift"; sourceTree = "<group>"; };
 		98C0D06328FCE99300E0E439 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		98C0D06628FCE9DC00E0E439 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */; };
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
 		98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */; };
+		43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43956D2B28FF9F0100DD996F /* PostingWritingView.swift */; };
 		98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */; };
 		98C0D06428FCE99300E0E439 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06328FCE99300E0E439 /* JSON.swift */; };
 		98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06628FCE9DC00E0E439 /* Model.swift */; };
@@ -52,6 +53,7 @@
 		43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingCategoryViewController.swift; sourceTree = "<group>"; };
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationViewContoller.swift; sourceTree = "<group>"; };
+		43956D2B28FF9F0100DD996F /* PostingWritingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingWritingView.swift; sourceTree = "<group>"; };
 		98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayout+.swift"; sourceTree = "<group>"; };
 		98C0D06328FCE99300E0E439 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		98C0D06628FCE9DC00E0E439 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */,
 				4369690B28FE422100DEA89F /* PostingImageViewController.swift */,
 				98366F8B29019A3100E81E27 /* RoomCreationView */,
+				43956D2B28FF9F0100DD996F /* PostingWritingView.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 				26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */,
 				98C0D06428FCE99300E0E439 /* JSON.swift in Sources */,
 				98C0D06A28FCEA4900E0E439 /* ImagePicker.swift in Sources */,
+				43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */,
 				26E3748228FCDC0000997DA7 /* AppDelegate.swift in Sources */,
 				43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */,
 				26E3748428FCDC0000997DA7 /* SceneDelegate.swift in Sources */,

--- a/Samsam/CoreData/CategoryEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/CategoryEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  CategoryEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(CategoryEntity)
+public class CategoryEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/CategoryEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/CategoryEntity+CoreDataProperties.swift
@@ -1,0 +1,62 @@
+//
+//  CategoryEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension CategoryEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CategoryEntity> {
+        return NSFetchRequest<CategoryEntity>(entityName: "CategoryEntity")
+    }
+
+    @NSManaged public var categoryID: Int32
+    @NSManaged public var categoryName: String?
+    @NSManaged public var categoryToWorkingStatus: NSSet?
+    @NSManaged public var categoryToPosting: NSSet?
+
+}
+
+// MARK: Generated accessors for categoryToWorkingStatus
+extension CategoryEntity {
+
+    @objc(addCategoryToWorkingStatusObject:)
+    @NSManaged public func addToCategoryToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(removeCategoryToWorkingStatusObject:)
+    @NSManaged public func removeFromCategoryToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(addCategoryToWorkingStatus:)
+    @NSManaged public func addToCategoryToWorkingStatus(_ values: NSSet)
+
+    @objc(removeCategoryToWorkingStatus:)
+    @NSManaged public func removeFromCategoryToWorkingStatus(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for categoryToPosting
+extension CategoryEntity {
+
+    @objc(addCategoryToPostingObject:)
+    @NSManaged public func addToCategoryToPosting(_ value: PostingEntity)
+
+    @objc(removeCategoryToPostingObject:)
+    @NSManaged public func removeFromCategoryToPosting(_ value: PostingEntity)
+
+    @objc(addCategoryToPosting:)
+    @NSManaged public func addToCategoryToPosting(_ values: NSSet)
+
+    @objc(removeCategoryToPosting:)
+    @NSManaged public func removeFromCategoryToPosting(_ values: NSSet)
+
+}
+
+extension CategoryEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -1,0 +1,26 @@
+//
+//  CoreDataManager.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/23.
+//
+
+import CoreData
+import Foundation
+import UIKit
+class CoreDataManager {
+    
+    // MARK: - Property
+    
+    // MARK: - Save Method
+    
+    
+    // MARK: - Update Method
+    
+    
+    // MARK: - Load Method
+    
+    
+    // MARK: - Count Method
+    
+}

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -228,6 +228,23 @@ class CoreDataManager {
         }
     }
     
+    func loadOneRoomData(roomID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        do {
+            let room = try context.fetch(RoomEntity.fetchRequest()) as! [RoomEntity]
+            
+            room.forEach {
+                if $0.roomID == roomID {
+                    oneRoom = $0
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -65,6 +65,8 @@ enum Category: Int {
     }
 }
 
+let coreDataManager = CoreDataManager()
+
 class CoreDataManager {
     
     // MARK: - Property

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -167,6 +167,22 @@ class CoreDataManager {
     
     // MARK: - Update Method
     
+    func updateRoomData(room: RoomEntity, clientName: String, startDate: Date, endDate: Date, warrantyTime: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        room.clientName = clientName
+        room.startDate = startDate
+        room.endDate = endDate
+        room.warrantyTime = Int32(warrantyTime)
+        
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Load Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -145,6 +145,25 @@ class CoreDataManager {
         }
     }
     
+    func createPhotoData(postingID: Int, photoPath: Data) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let photoEntity = NSEntityDescription.entity(forEntityName: "PhotoEntity", in: context)
+        
+        if let photoEntity = photoEntity {
+            let photo = NSManagedObject(entity: photoEntity, insertInto: context)
+            photo.setValue(coreDataManager.countData(dataType: "photo"), forKey: "photoID")
+            photo.setValue(postingID, forKey: "postingID")
+            photo.setValue(photoPath, forKey: "photoPath")
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
     
     // MARK: - Update Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -76,7 +76,30 @@ class CoreDataManager {
     
     @Published var oneRoom: RoomEntity?
     
-    // MARK: - Save Method
+    // MARK: - Create Method
+    
+    func createRoomData(clientName: String, startDate: Date, endDate: Date, warrantyTime: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let roomEntity = NSEntityDescription.entity(forEntityName: "RoomEntity", in: context)
+        
+        if let roomEntity = roomEntity {
+            let room = NSManagedObject(entity: roomEntity, insertInto: context)
+            room.setValue(coreDataManager.countData(dataType: "room"), forKey: "roomID")
+            room.setValue(clientName, forKey: "clientName")
+            room.setValue(startDate, forKey: "startDate")
+            room.setValue(endDate, forKey: "endDate")
+            room.setValue(warrantyTime, forKey: "warrantyTime")
+            // 방상태 어떻게 하더라?
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
     
     
     // MARK: - Update Method

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -183,6 +183,19 @@ class CoreDataManager {
         }
     }
     
+    func updateWorkingStatusData(workingStatus: WorkingStatusEntity, status: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        workingStatus.status = Int32(status)
+        
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Load Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -93,7 +93,6 @@ class CoreDataManager {
             room.setValue(startDate, forKey: "startDate")
             room.setValue(endDate, forKey: "endDate")
             room.setValue(warrantyTime, forKey: "warrantyTime")
-            // 방상태 어떻게 하더라?
             
             do {
                 try context.save()

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -245,6 +245,25 @@ class CoreDataManager {
         }
     }
     
+    func loadWorkingStatusData(roomID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        workingStatuses = [WorkingStatusEntity]()
+        
+        do {
+            let workingStatus = try context.fetch(WorkingStatusEntity.fetchRequest()) as! [WorkingStatusEntity]
+            
+            workingStatus.forEach {
+                if $0.roomID == roomID {
+                    workingStatuses.append($0)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -283,6 +283,24 @@ class CoreDataManager {
         }
     }
     
+    func loadPhotoData(postingID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        photos = [PhotoEntity]()
+        
+        do {
+            let photo = try context.fetch(PhotoEntity.fetchRequest()) as! [PhotoEntity]
+            
+            photo.forEach {
+                if $0.postingID == postingID {
+                    photos.append($0)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -304,4 +304,26 @@ class CoreDataManager {
     
     // MARK: - Count Method
     
+    func countData(dataType: String) -> Int {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        do {
+            switch(dataType) {
+            case "room":
+                return try context.fetch(RoomEntity.fetchRequest()).count
+            case "workingStatus":
+                return try context.fetch(WorkingStatusEntity.fetchRequest()).count
+            case "posting":
+                return try context.fetch(PostingEntity.fetchRequest()).count
+            case "photo":
+                return try context.fetch(PhotoEntity.fetchRequest()).count
+            default:
+                return 0
+            }
+        } catch {
+            print(error.localizedDescription)
+            return 0
+        }
+    }
 }

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -69,6 +69,13 @@ class CoreDataManager {
     
     // MARK: - Property
     
+    @Published var rooms = [RoomEntity]()
+    @Published var workingStatuses = [WorkingStatusEntity]()
+    @Published var postings = [PostingEntity]()
+    @Published var photos = [PhotoEntity]()
+    
+    @Published var oneRoom: RoomEntity?
+    
     // MARK: - Save Method
     
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -196,6 +196,18 @@ class CoreDataManager {
         }
     }
     
+    func updatePostingData(posting: PostingEntity, explanation: String) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        posting.explanation = explanation
+        
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
     
     // MARK: - Load Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -123,6 +123,28 @@ class CoreDataManager {
         }
     }
     
+    func createPostingData(roomID: Int, categoryID: Int, explanation: String) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let postingEntity = NSEntityDescription.entity(forEntityName: "PostingEntity", in: context)
+        
+        if let postingEntity = postingEntity {
+            let posting = NSManagedObject(entity: postingEntity, insertInto: context)
+            posting.setValue(coreDataManager.countData(dataType: "posting"), forKey: "postingID")
+            posting.setValue(roomID, forKey: "roomID")
+            posting.setValue(categoryID, forKey: "categoryID")
+            posting.setValue(explanation, forKey: "explanation")
+            posting.setValue(Date(), forKey: "createDate")
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
     
     // MARK: - Update Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -8,6 +8,63 @@
 import CoreData
 import Foundation
 import UIKit
+
+enum Category: Int {
+    case zero = 0
+    case one = 1
+    case two = 2
+    case three = 3
+    case four = 4
+    case five = 5
+    case six = 6
+    case seven = 7
+    case eight = 8
+    case nine = 9
+    case ten = 10
+    case eleven = 11
+    case twelve = 12
+    case thirteen = 13
+    case fourteen = 14
+    case fifteen = 15
+    
+    func categoryName() -> String {
+        switch self {
+        case .zero:
+            return "실측"
+        case .one:
+            return "철거"
+        case .two:
+            return "설비"
+        case .three:
+            return "새시"
+        case .four:
+            return "목공"
+        case .five:
+            return "전기"
+        case .six:
+            return "페인트"
+        case .seven:
+            return "필름"
+        case .eight:
+            return "타일"
+        case .nine:
+            return "욕실"
+        case .ten:
+            return "마루"
+        case .eleven:
+            return "도배"
+        case .twelve:
+            return "주방"
+        case .thirteen:
+            return "폴딩도어"
+        case .fourteen:
+            return "조명"
+        case .fifteen:
+            return "기타"
+        }
+    }
+}
+
 class CoreDataManager {
     
     // MARK: - Property

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -101,6 +101,28 @@ class CoreDataManager {
         }
     }
     
+    func createWorkingStatusData(roomID: Int, categoryID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let workingStatusEntity = NSEntityDescription.entity(forEntityName: "WorkingStatusEntity", in: context)
+        
+        if let workingStatusEntity = workingStatusEntity {
+            let workingStatus = NSManagedObject(entity: workingStatusEntity, insertInto: context)
+            workingStatus.setValue(coreDataManager.countData(dataType: "workingStatus"), forKey: "statusID")
+            workingStatus.setValue(roomID, forKey: "roomID")
+            workingStatus.setValue(categoryID, forKey: "categoryID")
+            workingStatus.setValue(0, forKey: "status")
+            // 0: 시작안함, 1: 진행중, 2: 완료, 3: 삭제
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
     
     // MARK: - Update Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -264,6 +264,25 @@ class CoreDataManager {
         }
     }
     
+    func loadPostingData(roomID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        postings = [PostingEntity]()
+        
+        do {
+            let posting = try context.fetch(PostingEntity.fetchRequest()) as! [PostingEntity]
+            
+            posting.forEach {
+                if $0.roomID == roomID {
+                    postings.append($0)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -211,6 +211,23 @@ class CoreDataManager {
     
     // MARK: - Load Method
     
+    func loadAllRoomData() {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        rooms = [RoomEntity]()
+        
+        do {
+            let room = try context.fetch(RoomEntity.fetchRequest()) as! [RoomEntity]
+            
+            room.forEach {
+                rooms.append($0)
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
+++ b/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
@@ -25,7 +25,6 @@
     <entity name="RoomEntity" representedClassName="RoomEntity" syncable="YES">
         <attribute name="clientName" optional="YES" attributeType="String"/>
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="inviteCode" optional="YES" attributeType="String"/>
         <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="warrantyTime" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
+++ b/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CategoryEntity" representedClassName="CategoryEntity" syncable="YES">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="categoryName" optional="YES" attributeType="String"/>
+        <relationship name="categoryToPosting" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PostingEntity" inverseName="postingToCategory" inverseEntity="PostingEntity"/>
+        <relationship name="categoryToWorkingStatus" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WorkingStatusEntity" inverseName="workingStatusToCategory" inverseEntity="WorkingStatusEntity"/>
+    </entity>
+    <entity name="PhotoEntity" representedClassName="PhotoEntity" syncable="YES">
+        <attribute name="photoID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="photoPath" optional="YES" attributeType="Binary"/>
+        <attribute name="postingID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="photoToPosting" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PostingEntity" inverseName="postingToPhoto" inverseEntity="PostingEntity"/>
+    </entity>
+    <entity name="PostingEntity" representedClassName="PostingEntity" syncable="YES">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="explanation" optional="YES" attributeType="String"/>
+        <attribute name="postingID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="postingToCategory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CategoryEntity" inverseName="categoryToPosting" inverseEntity="CategoryEntity"/>
+        <relationship name="postingToPhoto" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PhotoEntity" inverseName="photoToPosting" inverseEntity="PhotoEntity"/>
+        <relationship name="postingToRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RoomEntity" inverseName="roomToPosting" inverseEntity="RoomEntity"/>
+    </entity>
+    <entity name="RoomEntity" representedClassName="RoomEntity" syncable="YES">
+        <attribute name="clientName" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="inviteCode" optional="YES" attributeType="String"/>
+        <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="warrantyTime" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="roomToPosting" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PostingEntity" inverseName="postingToRoom" inverseEntity="PostingEntity"/>
+        <relationship name="roomToWorkingStatus" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WorkingStatusEntity" inverseName="workingStatusToRoom" inverseEntity="WorkingStatusEntity"/>
+    </entity>
+    <entity name="WorkingStatusEntity" representedClassName="WorkingStatusEntity" syncable="YES">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="workingStatusToCategory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CategoryEntity" inverseName="categoryToWorkingStatus" inverseEntity="CategoryEntity"/>
+        <relationship name="workingStatusToRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RoomEntity" inverseName="roomToWorkingStatus" inverseEntity="RoomEntity"/>
+    </entity>
+</model>

--- a/Samsam/CoreData/PhotoEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/PhotoEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  PhotoEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(PhotoEntity)
+public class PhotoEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/PhotoEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/PhotoEntity+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  PhotoEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension PhotoEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<PhotoEntity> {
+        return NSFetchRequest<PhotoEntity>(entityName: "PhotoEntity")
+    }
+
+    @NSManaged public var photoID: Int32
+    @NSManaged public var photoPath: Data?
+    @NSManaged public var postingID: Int32
+    @NSManaged public var photoToPosting: PostingEntity?
+
+}
+
+extension PhotoEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/PostingEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/PostingEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  PostingEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(PostingEntity)
+public class PostingEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/PostingEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/PostingEntity+CoreDataProperties.swift
@@ -1,0 +1,49 @@
+//
+//  PostingEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension PostingEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<PostingEntity> {
+        return NSFetchRequest<PostingEntity>(entityName: "PostingEntity")
+    }
+
+    @NSManaged public var categoryID: Int32
+    @NSManaged public var createDate: Date?
+    @NSManaged public var explanation: String?
+    @NSManaged public var postingID: Int32
+    @NSManaged public var roomID: Int32
+    @NSManaged public var postingToCategory: CategoryEntity?
+    @NSManaged public var postingToRoom: RoomEntity?
+    @NSManaged public var postingToPhoto: NSSet?
+
+}
+
+// MARK: Generated accessors for postingToPhoto
+extension PostingEntity {
+
+    @objc(addPostingToPhotoObject:)
+    @NSManaged public func addToPostingToPhoto(_ value: PhotoEntity)
+
+    @objc(removePostingToPhotoObject:)
+    @NSManaged public func removeFromPostingToPhoto(_ value: PhotoEntity)
+
+    @objc(addPostingToPhoto:)
+    @NSManaged public func addToPostingToPhoto(_ values: NSSet)
+
+    @objc(removePostingToPhoto:)
+    @NSManaged public func removeFromPostingToPhoto(_ values: NSSet)
+
+}
+
+extension PostingEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/RoomEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/RoomEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  RoomEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(RoomEntity)
+public class RoomEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
@@ -1,0 +1,66 @@
+//
+//  RoomEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension RoomEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<RoomEntity> {
+        return NSFetchRequest<RoomEntity>(entityName: "RoomEntity")
+    }
+
+    @NSManaged public var clientName: String?
+    @NSManaged public var endDate: Date?
+    @NSManaged public var inviteCode: String?
+    @NSManaged public var roomID: Int32
+    @NSManaged public var startDate: Date?
+    @NSManaged public var warrantyTime: Int32
+    @NSManaged public var roomToWorkingStatus: NSSet?
+    @NSManaged public var roomToPosting: NSSet?
+
+}
+
+// MARK: Generated accessors for roomToWorkingStatus
+extension RoomEntity {
+
+    @objc(addRoomToWorkingStatusObject:)
+    @NSManaged public func addToRoomToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(removeRoomToWorkingStatusObject:)
+    @NSManaged public func removeFromRoomToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(addRoomToWorkingStatus:)
+    @NSManaged public func addToRoomToWorkingStatus(_ values: NSSet)
+
+    @objc(removeRoomToWorkingStatus:)
+    @NSManaged public func removeFromRoomToWorkingStatus(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for roomToPosting
+extension RoomEntity {
+
+    @objc(addRoomToPostingObject:)
+    @NSManaged public func addToRoomToPosting(_ value: PostingEntity)
+
+    @objc(removeRoomToPostingObject:)
+    @NSManaged public func removeFromRoomToPosting(_ value: PostingEntity)
+
+    @objc(addRoomToPosting:)
+    @NSManaged public func addToRoomToPosting(_ values: NSSet)
+
+    @objc(removeRoomToPosting:)
+    @NSManaged public func removeFromRoomToPosting(_ values: NSSet)
+
+}
+
+extension RoomEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
@@ -18,7 +18,6 @@ extension RoomEntity {
 
     @NSManaged public var clientName: String?
     @NSManaged public var endDate: Date?
-    @NSManaged public var inviteCode: String?
     @NSManaged public var roomID: Int32
     @NSManaged public var startDate: Date?
     @NSManaged public var warrantyTime: Int32

--- a/Samsam/CoreData/WorkingStatusEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/WorkingStatusEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  WorkingStatusEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(WorkingStatusEntity)
+public class WorkingStatusEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/WorkingStatusEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/WorkingStatusEntity+CoreDataProperties.swift
@@ -1,0 +1,30 @@
+//
+//  WorkingStatusEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension WorkingStatusEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WorkingStatusEntity> {
+        return NSFetchRequest<WorkingStatusEntity>(entityName: "WorkingStatusEntity")
+    }
+
+    @NSManaged public var categoryID: Int32
+    @NSManaged public var roomID: Int32
+    @NSManaged public var status: Int32
+    @NSManaged public var statusID: Int32
+    @NSManaged public var workingStatusToCategory: CategoryEntity?
+    @NSManaged public var workingStatusToRoom: RoomEntity?
+
+}
+
+extension WorkingStatusEntity : Identifiable {
+
+}

--- a/Samsam/Global/AppDelegate.swift
+++ b/Samsam/Global/AppDelegate.swift
@@ -25,27 +25,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     // MARK: - Core Data stack
-        lazy var persistentContainer: NSPersistentContainer = {
-            let container = NSPersistentContainer(name: "DataTable")
-            container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-                if let error = error as NSError? {
-                    fatalError("Unresolved error \(error), \(error.userInfo)")
-                }
-            })
-            return container
-        }()
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "DataTable")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
 
-        // MARK: - Core Data Saving support
-        func saveContext () {
-            let context = persistentContainer.viewContext
-            if context.hasChanges {
-                do {
-                    try context.save()
-                } catch {
-                    let nserror = error as NSError
-                    fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-                }
+    // MARK: - Core Data Saving support
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
             }
         }
+    }
 }
 

--- a/Samsam/Global/AppDelegate.swift
+++ b/Samsam/Global/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 김민택 on 2022/10/17.
 //
 
+import CoreData
 import UIKit
 
 @main
@@ -22,7 +23,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
     }
+    
+    // MARK: - Core Data stack
+        lazy var persistentContainer: NSPersistentContainer = {
+            let container = NSPersistentContainer(name: "DataTable")
+            container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+                if let error = error as NSError? {
+                    fatalError("Unresolved error \(error), \(error.userInfo)")
+                }
+            })
+            return container
+        }()
 
-
+        // MARK: - Core Data Saving support
+        func saveContext () {
+            let context = persistentContainer.viewContext
+            if context.hasChanges {
+                do {
+                    try context.save()
+                } catch {
+                    let nserror = error as NSError
+                    fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+                }
+            }
+        }
 }
 

--- a/Samsam/Global/SceneDelegate.swift
+++ b/Samsam/Global/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        let navi = UINavigationController(rootViewController: ViewController())
+        let navi = UINavigationController(rootViewController: PostingWritingView())
         window?.rootViewController = navi
         window?.makeKeyAndVisible()
     }

--- a/Samsam/Global/SceneDelegate.swift
+++ b/Samsam/Global/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        let navi = UINavigationController(rootViewController: PostingWritingView())
+        let navi = UINavigationController(rootViewController: ViewController())
         window?.rootViewController = navi
         window?.makeKeyAndVisible()
     }

--- a/Samsam/Samsam.entitlements
+++ b/Samsam/Samsam.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-</dict>
+<dict/>
 </plist>

--- a/Samsam/Samsam.entitlements
+++ b/Samsam/Samsam.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -145,8 +145,8 @@ class PostingWritingView: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
-    @objc func tapNextBtn(_sender: UIButton) {
-            navigationController?.popToRootViewController(animated: true)
+    @objc func tapNextbtn(_sender: UIButton) {
+        navigationController?.popToRootViewController(animated: true)
     }
     
     @objc private func keyboardWillShow(notification: NSNotification) {

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -23,7 +23,7 @@ class PostingWritingView: UIViewController {
         return $0
     }(UILabel())
     
-    lazy var textContent: UITextView = {
+    private lazy var textContent: UITextView = {
         let linestyle = NSMutableParagraphStyle()
         linestyle.lineSpacing = 6.0
         $0.backgroundColor = .clear

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -45,7 +45,7 @@ class PostingWritingView: UIViewController {
         $0.backgroundColor = .gray
         $0.layer.cornerRadius = 10
         $0.layer.shadowColor = UIColor.black.cgColor
-        $0.layer.shadowOpacity = 0.2
+        $0.layer.shadowOpacity = 0.25
         $0.layer.shadowOffset = CGSize(width: 2, height: 2)
         $0.layer.shadowRadius = 10
         return $0

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -98,8 +98,10 @@ class PostingWritingView: UIViewController {
             height: 280
         )
         
+        finalbtn.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
-            right: view.rightAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
             paddingLeft: 16,
             paddingRight: 16,
             height: 50
@@ -107,8 +109,8 @@ class PostingWritingView: UIViewController {
         
         shadowView.anchor(
             top: textTitle.bottomAnchor,
-            left: view.leftAnchor,
-            right: view.rightAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
             paddingTop: 20,
             paddingLeft: 16,
             paddingRight: 16,

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -8,6 +8,10 @@
 import UIKit
 
 class PostingWritingView: UIViewController {
+    
+    // MARK: - Property
+    
+    private let textViewPlaceHolder = "텍스트를 입력하세요"
 
     // MARK: - View
     
@@ -18,8 +22,6 @@ class PostingWritingView: UIViewController {
         $0.textColor = .black
         return $0
     }(UILabel())
-
-    let textViewPlaceHolder = "텍스트를 입력하세요"
     
     lazy var textContent: UITextView = {
         let linestyle = NSMutableParagraphStyle()

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -57,7 +57,7 @@ class PostingWritingView: UIViewController {
             $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
             $0.setTitleColor(.black, for: .normal)
             $0.layer.cornerRadius = 16
-            $0.addTarget(self, action: #selector(tapNextBTN), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(tapNextbtn(_sender:)), for: .touchUpInside)
             return $0
         }(UIButton())
     
@@ -144,7 +144,7 @@ class PostingWritingView: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
-    @objc func tapNextBTN() {
+    @objc func tapNextbtn(_sender: UIButton) {
         navigationController?.popToRootViewController(animated: true)
     }
     

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -25,13 +25,13 @@ class PostingWritingView: UIViewController {
     
     private lazy var textContent: UITextView = {
         let linestyle = NSMutableParagraphStyle()
-        linestyle.lineSpacing = 6.0
+        linestyle.lineSpacing = 4.0
+        $0.typingAttributes = [.paragraphStyle: linestyle]
         $0.backgroundColor = .clear
         $0.text = textViewPlaceHolder
         $0.textColor = .lightGray
         $0.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         $0.textAlignment = .natural
-        $0.typingAttributes = [.paragraphStyle: linestyle]
         $0.textContainerInset = UIEdgeInsets(top: 17, left: 12, bottom: 17, right: 12)
         $0.layer.masksToBounds = true
         $0.layer.cornerRadius = 10

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -121,7 +121,6 @@ class PostingWritingView: UIViewController {
     private func setupNavigationTitle() {
         let appearance = UINavigationBarAppearance()
         
-        appearance.backgroundColor = .white
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.backgroundColor = .white

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -22,7 +22,6 @@ class PostingWritingView: UIViewController {
     lazy var textContent: UITextView = {
         let linestyle = NSMutableParagraphStyle()
         linestyle.lineSpacing = 6.0
-        
         $0.backgroundColor = .white
         $0.text = "시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요"
         $0.textColor = .black
@@ -64,6 +63,7 @@ class PostingWritingView: UIViewController {
         attribute()
         layout()
         hidekeyboardWhenTappedAround()
+        setupNotificationCenter()
     }
     
     // MARK: - Method
@@ -90,7 +90,7 @@ class PostingWritingView: UIViewController {
         textContent.anchor(
             left: shadowView.leftAnchor,
             right: shadowView.rightAnchor,
-            height: 330
+            height: 280
         )
         
         finalBtn.anchor(
@@ -109,7 +109,7 @@ class PostingWritingView: UIViewController {
             paddingTop: 20,
             paddingLeft: 16,
             paddingRight: 16,
-            height: 330
+            height: 280
         )
     }
     
@@ -135,7 +135,27 @@ class PostingWritingView: UIViewController {
         view.endEditing(true)
     }
     
+    private func setupNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
     @objc func tapNextBtn(_sender: UIButton) {
             navigationController?.popToRootViewController(animated: true)
     }
+    
+    @objc private func keyboardWillShow(notification: NSNotification) {
+            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+                UIView.animate(withDuration: 0.2, animations: {
+                    self.finalBtn.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
+                })
+            }
+    }
+        
+    @objc private func keyboardWillHide(notification:NSNotification) {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.finalBtn.transform = .identity
+            })
+    }
+    
 }

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -19,12 +19,14 @@ class PostingWritingView: UIViewController {
         return $0
     }(UILabel())
 
+    let textViewPlaceHolder = "텍스트를 입력하세요"
+    
     lazy var textContent: UITextView = {
         let linestyle = NSMutableParagraphStyle()
         linestyle.lineSpacing = 6.0
-        $0.backgroundColor = .white
-        $0.text = "시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요"
-        $0.textColor = .black
+        $0.backgroundColor = .clear
+        $0.text = textViewPlaceHolder
+        $0.textColor = .gray
         $0.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         $0.textAlignment = .natural
         $0.typingAttributes = [.paragraphStyle: linestyle]
@@ -33,15 +35,16 @@ class PostingWritingView: UIViewController {
         $0.layer.cornerRadius = 10
         $0.autocorrectionType = .no
         $0.autocapitalizationType = .none
+        $0.delegate = self
         return $0
     }(UITextView())
     
     private var shadowView: UIView = {
-        $0.backgroundColor = .blue
+        $0.backgroundColor = .gray
         $0.layer.cornerRadius = 10
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.2
-        $0.layer.shadowOffset = CGSize(width: 1, height: 1)
+        $0.layer.shadowOffset = CGSize(width: 2, height: 2)
         $0.layer.shadowRadius = 10
         return $0
     }(UIView())
@@ -157,5 +160,20 @@ class PostingWritingView: UIViewController {
                 self.finalBtn.transform = .identity
             })
     }
+}
+
+extension PostingWritingView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == textViewPlaceHolder {
+            textView.text = nil
+            textView.textColor = .black
+        }
+    }
     
+    func textViewDidEndEditing(_ textView: UITextView) {
+            if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                textView.text = textViewPlaceHolder
+                textView.textColor = .lightGray
+        }
+    }
 }

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -51,13 +51,13 @@ class PostingWritingView: UIViewController {
         return $0
     }(UIView())
     
-    private let finalBtn: UIButton = {
+    private let finalbtn: UIButton = {
             $0.backgroundColor = .blue
             $0.setTitle("작성 완료", for: .normal)
             $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
             $0.setTitleColor(.black, for: .normal)
             $0.layer.cornerRadius = 16
-            $0.addTarget(self, action: #selector(tapNextBtn(_sender:)), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(tapNextbtn(_sender:)), for: .touchUpInside)
             return $0
         }(UIButton())
     
@@ -82,7 +82,7 @@ class PostingWritingView: UIViewController {
         self.view.addSubview(textTitle)
         self.view.addSubview(shadowView)
         self.shadowView.addSubview(textContent)
-        self.view.addSubview(finalBtn)
+        self.view.addSubview(finalbtn)
         
         textTitle.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
@@ -98,8 +98,6 @@ class PostingWritingView: UIViewController {
             height: 280
         )
         
-        finalBtn.anchor(
-            left: view.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.rightAnchor,
             paddingLeft: 16,

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -1,0 +1,95 @@
+//
+//  PostingWritingView.swift
+//  Samsam
+//
+//  Created by creohwan on 2022/10/19.
+//
+
+import UIKit
+
+class PostingWritingView: UIViewController {
+
+    // MARK: - View
+    
+    private var textTitle: UILabel = {
+        $0.text = "시공 사진에 관하여 부가 설명을 써주세요"
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
+        $0.textColor = .black
+        return $0
+    }(UILabel())
+
+    lazy var textContent: UITextView = {
+        let linestyle = NSMutableParagraphStyle()
+        
+        linestyle.lineSpacing = 6.0
+        
+        $0.backgroundColor = .white
+        $0.text = "시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요"
+        
+        $0.textColor = .black
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .regular)
+        $0.textAlignment = .natural
+        $0.typingAttributes = [.paragraphStyle: linestyle]
+        $0.textContainerInset = UIEdgeInsets(top: 17, left: 12, bottom: 17, right: 12)
+        $0.layer.masksToBounds = false
+        $0.layer.cornerRadius = 10
+        
+        $0.autocorrectionType = .no
+        $0.autocapitalizationType = .none
+        
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.2
+        $0.layer.shadowOffset = CGSize(width: 1, height: 1)
+        $0.layer.shadowRadius = 10
+  
+        return $0
+    }(UITextView())
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        attribute()
+        layout()
+        hidekeyboardWhenTappedAround()
+    }
+    
+    // MARK: - Method
+    
+    private func attribute() {
+        view.backgroundColor = .white
+        
+    }
+    
+    private func layout() {
+        self.view.addSubview(textTitle)
+        self.view.addSubview(textContent)
+        
+        textTitle.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            height: 20
+        )
+    
+        textContent.anchor(
+            top: textTitle.bottomAnchor,
+            left: textTitle.leftAnchor,
+            right: textTitle.rightAnchor,
+            paddingTop: 20,
+            paddingLeft: 16,
+            paddingBottom: 15,
+            paddingRight: 16,
+            height: 310
+        )
+    }
+    
+    func hidekeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func endEditingView() {
+        view.endEditing(true)
+    }
+}

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -69,6 +69,7 @@ class PostingWritingView: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
+        setupNavigationTitle()
         
     }
     
@@ -81,6 +82,7 @@ class PostingWritingView: UIViewController {
             top: view.safeAreaLayoutGuide.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 20,
             height: 20
         )
     
@@ -106,6 +108,18 @@ class PostingWritingView: UIViewController {
         
         
     }
+    
+    private func setupNavigationTitle() {
+            let appearance = UINavigationBarAppearance()
+            
+            appearance.backgroundColor = .white
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.scrollEdgeAppearance = appearance
+            navigationController?.navigationBar.backgroundColor = .white
+            navigationController?.navigationBar.topItem?.title = "시공 상황 작성"
+            navigationController?.navigationBar.prefersLargeTitles = false
+            navigationController?.setNavigationBarHidden(false, animated: false)
+        }
     
     func hidekeyboardWhenTappedAround() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -51,7 +51,7 @@ class PostingWritingView: UIViewController {
         return $0
     }(UIView())
     
-    private let finalbtn: UIButton = {
+    private let finalBTN: UIButton = {
             $0.backgroundColor = .blue
             $0.setTitle("작성 완료", for: .normal)
             $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
@@ -82,7 +82,7 @@ class PostingWritingView: UIViewController {
         self.view.addSubview(textTitle)
         self.view.addSubview(shadowView)
         self.shadowView.addSubview(textContent)
-        self.view.addSubview(finalbtn)
+        self.view.addSubview(finalBTN)
         
         textTitle.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
@@ -98,7 +98,7 @@ class PostingWritingView: UIViewController {
             height: 280
         )
         
-        finalbtn.anchor(
+        finalBTN.anchor(
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
@@ -151,14 +151,14 @@ class PostingWritingView: UIViewController {
     @objc private func keyboardWillShow(notification: NSNotification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             UIView.animate(withDuration: 0.2, animations: {
-                self.finalbtn.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
+                self.finalBTN.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
             })
         }
     }
     
     @objc private func keyboardWillHide(notification:NSNotification) {
         UIView.animate(withDuration: 0.2, animations: {
-            self.finalbtn.transform = .identity
+            self.finalBTN.transform = .identity
         })
     }
 }

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -57,7 +57,7 @@ class PostingWritingView: UIViewController {
             $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
             $0.setTitleColor(.black, for: .normal)
             $0.layer.cornerRadius = 16
-            $0.addTarget(self, action: #selector(tapNextbtn(_sender:)), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(tapNextBTN), for: .touchUpInside)
             return $0
         }(UIButton())
     
@@ -144,7 +144,7 @@ class PostingWritingView: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
-    @objc func tapNextbtn(_sender: UIButton) {
+    @objc func tapNextBTN() {
         navigationController?.popToRootViewController(animated: true)
     }
     

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -21,30 +21,31 @@ class PostingWritingView: UIViewController {
 
     lazy var textContent: UITextView = {
         let linestyle = NSMutableParagraphStyle()
-        
         linestyle.lineSpacing = 6.0
         
         $0.backgroundColor = .white
         $0.text = "시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요 시공 사진에 관하여 설명을 써봐주세요"
-        
         $0.textColor = .black
         $0.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         $0.textAlignment = .natural
         $0.typingAttributes = [.paragraphStyle: linestyle]
         $0.textContainerInset = UIEdgeInsets(top: 17, left: 12, bottom: 17, right: 12)
-        $0.layer.masksToBounds = false
+        $0.layer.masksToBounds = true
         $0.layer.cornerRadius = 10
-        
         $0.autocorrectionType = .no
         $0.autocapitalizationType = .none
-        
+        return $0
+    }(UITextView())
+    
+    private var shadowView: UIView = {
+        $0.backgroundColor = .blue
+        $0.layer.cornerRadius = 10
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.2
         $0.layer.shadowOffset = CGSize(width: 1, height: 1)
         $0.layer.shadowRadius = 10
-  
         return $0
-    }(UITextView())
+    }(UIView())
     
     private let finalBtn: UIButton = {
             $0.backgroundColor = .blue
@@ -70,12 +71,12 @@ class PostingWritingView: UIViewController {
     private func attribute() {
         view.backgroundColor = .white
         setupNavigationTitle()
-        
     }
     
     private func layout() {
         self.view.addSubview(textTitle)
-        self.view.addSubview(textContent)
+        self.view.addSubview(shadowView)
+        self.shadowView.addSubview(textContent)
         self.view.addSubview(finalBtn)
         
         textTitle.anchor(
@@ -87,14 +88,9 @@ class PostingWritingView: UIViewController {
         )
     
         textContent.anchor(
-            top: textTitle.bottomAnchor,
-            left: textTitle.leftAnchor,
-            right: textTitle.rightAnchor,
-            paddingTop: 20,
-            paddingLeft: 16,
-            paddingBottom: 15,
-            paddingRight: 16,
-            height: 310
+            left: shadowView.leftAnchor,
+            right: shadowView.rightAnchor,
+            height: 330
         )
         
         finalBtn.anchor(
@@ -106,7 +102,15 @@ class PostingWritingView: UIViewController {
             height: 50
         )
         
-        
+        shadowView.anchor(
+            top: textTitle.bottomAnchor,
+            left: view.leftAnchor,
+            right: view.rightAnchor,
+            paddingTop: 20,
+            paddingLeft: 16,
+            paddingRight: 16,
+            height: 330
+        )
     }
     
     private func setupNavigationTitle() {

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -46,6 +46,18 @@ class PostingWritingView: UIViewController {
         return $0
     }(UITextView())
     
+    private let finalBtn: UIButton = {
+            $0.backgroundColor = .blue
+            $0.setTitle("작성 완료", for: .normal)
+            $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+            $0.setTitleColor(.black, for: .normal)
+            $0.layer.cornerRadius = 16
+            $0.addTarget(self, action: #selector(tapNextBtn(_sender:)), for: .touchUpInside)
+            return $0
+        }(UIButton())
+    
+    // MARK: - Lifecycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         attribute()
@@ -63,6 +75,7 @@ class PostingWritingView: UIViewController {
     private func layout() {
         self.view.addSubview(textTitle)
         self.view.addSubview(textContent)
+        self.view.addSubview(finalBtn)
         
         textTitle.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
@@ -81,6 +94,17 @@ class PostingWritingView: UIViewController {
             paddingRight: 16,
             height: 310
         )
+        
+        finalBtn.anchor(
+            left: view.leftAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            right: view.rightAnchor,
+            paddingLeft: 16,
+            paddingRight: 16,
+            height: 50
+        )
+        
+        
     }
     
     func hidekeyboardWhenTappedAround() {
@@ -91,5 +115,9 @@ class PostingWritingView: UIViewController {
     
     @objc func endEditingView() {
         view.endEditing(true)
+    }
+    
+    @objc func tapNextBtn(_sender: UIButton) {
+            navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -26,7 +26,7 @@ class PostingWritingView: UIViewController {
         linestyle.lineSpacing = 6.0
         $0.backgroundColor = .clear
         $0.text = textViewPlaceHolder
-        $0.textColor = .gray
+        $0.textColor = .lightGray
         $0.font = UIFont.systemFont(ofSize: 18, weight: .regular)
         $0.textAlignment = .natural
         $0.typingAttributes = [.paragraphStyle: linestyle]

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -91,7 +91,7 @@ class PostingWritingView: UIViewController {
             paddingTop: 20,
             height: 20
         )
-    
+        
         textContent.anchor(
             left: shadowView.leftAnchor,
             right: shadowView.rightAnchor,
@@ -119,16 +119,16 @@ class PostingWritingView: UIViewController {
     }
     
     private func setupNavigationTitle() {
-            let appearance = UINavigationBarAppearance()
-            
-            appearance.backgroundColor = .white
-            navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.scrollEdgeAppearance = appearance
-            navigationController?.navigationBar.backgroundColor = .white
-            navigationController?.navigationBar.topItem?.title = "시공 상황 작성"
-            navigationController?.navigationBar.prefersLargeTitles = false
-            navigationController?.setNavigationBarHidden(false, animated: false)
-        }
+        let appearance = UINavigationBarAppearance()
+        
+        appearance.backgroundColor = .white
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.backgroundColor = .white
+        navigationController?.navigationBar.topItem?.title = "시공 상황 작성"
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationController?.setNavigationBarHidden(false, animated: false)
+    }
     
     func hidekeyboardWhenTappedAround() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))
@@ -150,17 +150,17 @@ class PostingWritingView: UIViewController {
     }
     
     @objc private func keyboardWillShow(notification: NSNotification) {
-            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-                UIView.animate(withDuration: 0.2, animations: {
-                    self.finalBtn.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
-                })
-            }
-    }
-        
-    @objc private func keyboardWillHide(notification:NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             UIView.animate(withDuration: 0.2, animations: {
-                self.finalBtn.transform = .identity
+                self.finalbtn.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
             })
+        }
+    }
+    
+    @objc private func keyboardWillHide(notification:NSNotification) {
+        UIView.animate(withDuration: 0.2, animations: {
+            self.finalbtn.transform = .identity
+        })
     }
 }
 
@@ -173,9 +173,9 @@ extension PostingWritingView: UITextViewDelegate {
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-            if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                textView.text = textViewPlaceHolder
-                textView.textColor = .lightGray
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = textViewPlaceHolder
+            textView.textColor = .lightGray
         }
     }
 }

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -93,7 +93,7 @@ class RoomCategoryViewController: UIViewController {
         navigationController?.navigationBar.backgroundColor = .white
         navigationController?.navigationBar.topItem?.title = "방 생성"
         navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.setNavigationBarHidden(false, animated: false)
+        navigationController?.setNavigationBarHidden(false, animated: true)
     }
     
     private func setTitleText() {

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -8,19 +8,42 @@
 import UIKit
 
 class RoomCategoryViewController: UIViewController {
+    
+    // MARK: - View
 
+    private var textTitle: UILabel = {
+        $0.text = "시공 항목을 모두 선택해주세요"
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
+        $0.textColor = .black
+        return $0
+    }(UILabel())
 
+    // MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        layout()
         attribute()
-
-
     }
     
     // MARK: - Method
     
     private func attribute() {
+        view.backgroundColor = .white
         setNavigationTitle()
+    }
+    
+    private func layout() {
+        view.addSubview(textTitle)
+        
+        textTitle.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 30,
+            height: 20
+        )
     }
     
     private func setNavigationTitle() {

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -11,7 +11,7 @@ class RoomCategoryViewController: UIViewController {
     
     // MARK: - View
 
-    private lazy var textTitle: UILabel = {
+    private var textTitle: UILabel = {
         $0.text = ""
         $0.textAlignment = .center
         $0.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
@@ -88,7 +88,6 @@ class RoomCategoryViewController: UIViewController {
     
     private func setNavigationTitle() {
         let appearance = UINavigationBarAppearance()
-        
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.backgroundColor = .white

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -102,7 +102,7 @@ class RoomCategoryViewController: UIViewController {
         titleText.attributedText = statement
     }
     
-    @objc func tapNextBTN(_sender: UIButton) {
+    @objc func tapNextBTN() {
         let vc = RoomCodeViewController()
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -11,7 +11,7 @@ class RoomCategoryViewController: UIViewController {
     
     // MARK: - View
 
-    private var textTitle: UILabel = {
+    private var titleText: UILabel = {
         $0.text = ""
         $0.textAlignment = .center
         $0.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
@@ -56,11 +56,11 @@ class RoomCategoryViewController: UIViewController {
     }
     
     private func layout() {
-        view.addSubview(textTitle)
+        view.addSubview(titleText)
         view.addSubview(nextBTN)
         view.addSubview(categoryView)
         
-        textTitle.anchor(
+        titleText.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
@@ -78,7 +78,7 @@ class RoomCategoryViewController: UIViewController {
         )
         
         categoryView.anchor(
-            top: textTitle.bottomAnchor,
+            top: titleText.bottomAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: nextBTN.topAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
@@ -98,8 +98,8 @@ class RoomCategoryViewController: UIViewController {
     
     private func setTitleText() {
         let statement = "시공 과정을 모두 선택해주세요".getColoredText("모두", .red)
-        textTitle.text = ""
-        textTitle.attributedText = statement
+        titleText.text = ""
+        titleText.attributedText = statement
     }
     
     @objc func tapNextBTN(_sender: UIButton) {

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -106,7 +106,6 @@ class RoomCategoryViewController: UIViewController {
         let vc = RoomCodeViewController()
         navigationController?.pushViewController(vc, animated: true)
     }
-    
 }
 
 extension NSMutableAttributedString {

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -68,6 +68,14 @@ class RoomCategoryViewController: UIViewController {
             height: 20
         )
         
+        categoryView.anchor(
+            top: titleText.bottomAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: nextBTN.topAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 20
+        )
+        
         nextBTN.anchor(
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
@@ -75,14 +83,6 @@ class RoomCategoryViewController: UIViewController {
             paddingLeft: 16,
             paddingRight: 16,
             height: 50
-        )
-        
-        categoryView.anchor(
-            top: titleText.bottomAnchor,
-            left: view.safeAreaLayoutGuide.leftAnchor,
-            bottom: nextBTN.topAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingTop: 20
         )
     }
     

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -25,7 +25,7 @@ class RoomCategoryViewController: UIViewController {
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.setTitleColor(.black, for: .normal)
         $0.layer.cornerRadius = 16
-        $0.addTarget(self, action: #selector(tapNextBTN(_sender:)), for: .touchUpInside)
+        $0.addTarget(self, action: #selector(tapNextBTN), for: .touchUpInside)
         return $0
     }(UIButton())
     

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -28,6 +28,11 @@ class RoomCategoryViewController: UIViewController {
         $0.addTarget(self, action: #selector(tapNextBTN(_sender:)), for: .touchUpInside)
         return $0
     }(UIButton())
+    
+    private let categoryView: UICollectionView = {
+        return $0
+    }(UICollectionView(
+        frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
 
     // MARK: - LifeCycle
     
@@ -40,14 +45,20 @@ class RoomCategoryViewController: UIViewController {
     // MARK: - Method
     
     private func attribute() {
-        view.backgroundColor = .white
+        self.view.backgroundColor = .white
         setNavigationTitle()
         setTitleText()
+        
+        categoryView.delegate = self
+        categoryView.dataSource = self
+        categoryView.allowsMultipleSelection = true
+        categoryView.register(CategoryCell.self, forCellWithReuseIdentifier: CategoryCell.identifier)
     }
     
     private func layout() {
         view.addSubview(textTitle)
         view.addSubview(nextBTN)
+        view.addSubview(categoryView)
         
         textTitle.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
@@ -64,6 +75,14 @@ class RoomCategoryViewController: UIViewController {
             paddingLeft: 16,
             paddingRight: 16,
             height: 50
+        )
+        
+        categoryView.anchor(
+            top: textTitle.bottomAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: nextBTN.topAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 20
         )
     }
     
@@ -106,4 +125,48 @@ extension String {
         return nsString
     }
 }
+
+// MARK: - UICollectionViewDelegate, DataSourse, DelegateFlowLayout
+
+extension RoomCategoryViewController:  UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 24
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCell.identifier, for: indexPath) as! CategoryCell
+        cell.categoryImage.image = UIImage(named: CategoryCell.ImageLiteral.noCheck)
+        cell.categoryTitle.text = "\(indexPath.item+1) 카테고리"
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        let cell = collectionView.cellForItem(at: indexPath)
+        if cell?.isSelected == false {
+            cell?.isSelected = true
+        }
+        return true
+    }
+
+    func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
+        let cell = collectionView.cellForItem(at: indexPath)
+        if cell?.isSelected == true {
+            cell?.isSelected = false
+        }
+        return true
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let cellWidth =  (view.frame.width - 48)/3
+        let cellHeight = 120
+        return CGSize(width: Int(cellWidth), height: Int(cellHeight))
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+         return UIEdgeInsets(top: 8, left: 8, bottom: 16, right: 8)
+    }
+}
+
 

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -11,8 +11,8 @@ class RoomCategoryViewController: UIViewController {
     
     // MARK: - View
 
-    private var textTitle: UILabel = {
-        $0.text = "시공 항목을 모두 선택해주세요"
+    private lazy var textTitle: UILabel = {
+        $0.text = ""
         $0.textAlignment = .center
         $0.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
         $0.textColor = .black
@@ -32,6 +32,7 @@ class RoomCategoryViewController: UIViewController {
     private func attribute() {
         view.backgroundColor = .white
         setNavigationTitle()
+        setTitleText()
     }
     
     private func layout() {
@@ -56,6 +57,28 @@ class RoomCategoryViewController: UIViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
+    
+    private func setTitleText() {
+        let statement = "시공 과정을 모두 선택해주세요".getColoredText("모두", .red)
+        textTitle.text = ""
+        textTitle.attributedText = statement
+    }
+    
 }
 
+extension NSMutableAttributedString {
+    func setColorForText(textToFind: String, withColor color: UIColor) {
+        let range = self.mutableString.range(of: textToFind, options: .caseInsensitive)
+        self.addAttribute(NSAttributedString.Key.foregroundColor, value: color, range: range)
+    }
+}
+
+extension String {
+    func getColoredText(_ text: String, _ color: UIColor) -> NSMutableAttributedString {
+        let nsString = NSMutableAttributedString(string: self)
+        nsString.setColorForText(textToFind: self, withColor: UIColor.black)
+        nsString.setColorForText(textToFind: text, withColor: color)
+        return nsString
+    }
+}
 

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -1,0 +1,38 @@
+//
+//  RoomCategoryViewController.swift
+//  Samsam
+//
+//  Created by creohwan on 2022/10/20.
+//
+
+import UIKit
+
+class RoomCategoryViewController: UIViewController {
+
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        attribute()
+
+
+    }
+    
+    // MARK: - Method
+    
+    private func attribute() {
+        setNavigationTitle()
+    }
+    
+    private func setNavigationTitle() {
+        let appearance = UINavigationBarAppearance()
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.backgroundColor = .white
+        navigationController?.navigationBar.topItem?.title = "방 생성"
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+}
+
+

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -18,6 +18,16 @@ class RoomCategoryViewController: UIViewController {
         $0.textColor = .black
         return $0
     }(UILabel())
+    
+    private let nextBTN: UIButton = {
+        $0.backgroundColor = .blue
+        $0.setTitle("방 생성하기", for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.setTitleColor(.black, for: .normal)
+        $0.layer.cornerRadius = 16
+        $0.addTarget(self, action: #selector(tapNextBTN(_sender:)), for: .touchUpInside)
+        return $0
+    }(UIButton())
 
     // MARK: - LifeCycle
     
@@ -37,6 +47,7 @@ class RoomCategoryViewController: UIViewController {
     
     private func layout() {
         view.addSubview(textTitle)
+        view.addSubview(nextBTN)
         
         textTitle.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
@@ -44,6 +55,15 @@ class RoomCategoryViewController: UIViewController {
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingTop: 30,
             height: 20
+        )
+        
+        nextBTN.anchor(
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingLeft: 16,
+            paddingRight: 16,
+            height: 50
         )
     }
     
@@ -62,6 +82,11 @@ class RoomCategoryViewController: UIViewController {
         let statement = "시공 과정을 모두 선택해주세요".getColoredText("모두", .red)
         textTitle.text = ""
         textTitle.attributedText = statement
+    }
+    
+    @objc func tapNextBTN(_sender: UIButton) {
+        let vc = RoomCodeViewController()
+        navigationController?.pushViewController(vc, animated: true)
     }
     
 }

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -159,7 +159,7 @@ extension RoomCategoryViewController:  UICollectionViewDelegate, UICollectionVie
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let cellWidth =  (view.frame.width - 48)/3
         let cellHeight = 120
-        return CGSize(width: Int(cellWidth), height: Int(cellHeight))
+        return CGSize(width: Int(cellWidth), height: cellHeight)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {

--- a/Samsam/ViewController/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCategoryViewController.swift
@@ -87,10 +87,6 @@ class RoomCategoryViewController: UIViewController {
     }
     
     private func setNavigationTitle() {
-        let appearance = UINavigationBarAppearance()
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.backgroundColor = .white
         navigationController?.navigationBar.topItem?.title = "방 생성"
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.setNavigationBarHidden(false, animated: true)

--- a/Samsam/ViewController/RoomCodeViewController.swift
+++ b/Samsam/ViewController/RoomCodeViewController.swift
@@ -1,0 +1,16 @@
+//
+//  RoomCodeViewController.swift
+//  Samsam
+//
+//  Created by creohwan on 2022/10/21.
+//
+
+import UIKit
+
+class RoomCodeViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .lightGray
+    }
+}

--- a/Samsam/ViewController/RoomCreationCell.swift
+++ b/Samsam/ViewController/RoomCreationCell.swift
@@ -15,7 +15,7 @@ class RoomCreationCell: UICollectionViewCell {
     
     // MARK: - View
     
-    private let creationButton: UIButton = {
+    let creationButton: UIButton = {
         $0.setImage(UIImage(systemName: "plus"), for: .normal)
         $0.tintColor = .black
         $0.setTitle("고객 추가하기", for: .normal)

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -24,16 +24,13 @@ class RoomCreationViewController: UIViewController {
         return $0
     }(UIStackView())
     
-    private let closeButton: UILabel = {
-        let attributedString = NSMutableAttributedString(string: "")
-        let imageTransition = NSTextAttachment()
-        imageTransition.image = UIImage(systemName: "xmark")
-        attributedString.append(NSMutableAttributedString(attachment: imageTransition))
-        $0.attributedText = attributedString
+    private let closeButton: UIButton = {
+        $0.setImage(UIImage(systemName: "xmark"), for: .normal)
+        $0.contentHorizontalAlignment = .left
         $0.tintColor = .black
         $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
         return $0
-    }(UILabel())
+    }(UIButton())
     
     private let viewTitle: UILabel = {
         $0.text = "방 생성"
@@ -160,7 +157,7 @@ class RoomCreationViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
-        setCloseButton()
+        closeButton.addTarget(self, action: #selector(tapCloseButton), for: .touchUpInside)
         nextButton.addTarget(self, action: #selector(tapNextButton), for: .touchUpInside)
     }
     
@@ -262,12 +259,6 @@ class RoomCreationViewController: UIViewController {
             right: uiView.rightAnchor,
             height: 50
         )
-    }
-    
-    private func setCloseButton() {
-        let tapCloseButton = UITapGestureRecognizer(target: self, action: #selector(tapCloseButton))
-        self.closeButton.isUserInteractionEnabled = true
-        self.closeButton.addGestureRecognizer(tapCloseButton)
     }
     
     @objc private func tapStepper() {

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -19,6 +19,36 @@ class RoomCreationViewController: UIViewController {
         return $0
     }(UIView())
     
+    private let titleHstack: UIStackView = {
+        $0.axis = .horizontal
+        return $0
+    }(UIStackView())
+    
+    private let closeButton: UILabel = {
+        let attributedString = NSMutableAttributedString(string: "")
+        let imageTransition = NSTextAttachment()
+        imageTransition.image = UIImage(systemName: "xmark")
+        attributedString.append(NSMutableAttributedString(attachment: imageTransition))
+        $0.attributedText = attributedString
+        $0.tintColor = .black
+        $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
+        return $0
+    }(UILabel())
+    
+    private let viewTitle: UILabel = {
+        $0.text = "방 생성"
+        $0.textColor = .black
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
+        return $0
+    }(UILabel())
+    
+    private let spacer: UIView = {
+        $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
+        return $0
+    }(UIView())
+    
     private let customerTitle: UILabel = {
         $0.text = "고객명/주소"
         $0.textAlignment = .left
@@ -130,12 +160,18 @@ class RoomCreationViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
-        setNavigationbar()
+        setCloseButton()
         nextButton.addTarget(self, action: #selector(tapNextButton), for: .touchUpInside)
     }
     
     private func layout() {
         view.addSubview(uiView)
+        
+        uiView.addSubview(titleHstack)
+        titleHstack.addArrangedSubview(closeButton)
+        titleHstack.addArrangedSubview(viewTitle)
+        titleHstack.addArrangedSubview(spacer)
+        
         uiView.addSubview(customerTitle)
         uiView.addSubview(customerTextField)
         uiView.addSubview(textUnderLine)
@@ -160,14 +196,21 @@ class RoomCreationViewController: UIViewController {
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingTop: 40,
+            paddingTop: 10,
             paddingLeft: 16,
             paddingBottom: 16,
             paddingRight: 16
         )
         
-        customerTitle.anchor(
+        titleHstack.anchor(
             top: uiView.topAnchor,
+            left: uiView.leftAnchor,
+            bottom: customerTitle.topAnchor,
+            right: uiView.rightAnchor,
+            paddingBottom: 40
+        )
+        
+        customerTitle.anchor(
             left: uiView.leftAnchor,
             bottom: customerTextField.topAnchor,
             right: uiView.rightAnchor,
@@ -221,13 +264,10 @@ class RoomCreationViewController: UIViewController {
         )
     }
     
-    private func setNavigationbar() {
-        let appearance = UINavigationBarAppearance()
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.topItem?.title = "방 생성"
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.setNavigationBarHidden(false, animated: true)
+    private func setCloseButton() {
+        let tapCloseButton = UITapGestureRecognizer(target: self, action: #selector(tapCloseButton))
+        self.closeButton.isUserInteractionEnabled = true
+        self.closeButton.addGestureRecognizer(tapCloseButton)
     }
     
     @objc private func tapStepper() {
@@ -240,5 +280,9 @@ class RoomCreationViewController: UIViewController {
     @objc private func tapNextButton() {
         let VC = ViewController()
         navigationController?.pushViewController(VC, animated: true)
+    }
+    
+    @objc private func tapCloseButton() {
+        self.dismiss(animated: true)
     }
 }

--- a/Samsam/ViewController/RoomListCell.swift
+++ b/Samsam/ViewController/RoomListCell.swift
@@ -20,7 +20,7 @@ class RoomListCell: UICollectionViewCell {
         return $0
     }(UIStackView())
     
-    private let roomStack: UIStackView = {
+    let roomStack: UIStackView = {
         $0.axis = .horizontal
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 16

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -45,7 +45,9 @@ class RoomListViewController: UIViewController {
     }
     
     private func setupNavigationTitle() {
-        navigationController?.navigationBar.topItem?.title = "앱 이름"
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        navigationItem.backBarButtonItem = backBarButtonItem
+        navigationItem.title = "앱 이름"
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
@@ -79,6 +81,10 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
             return cell
         }
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RoomListCell.identifier, for: indexPath) as! RoomListCell
+        
+        let tapRoomListButton = UITapGestureRecognizer(target: self, action: #selector(tapRoomListButton))
+        cell.roomStack.isUserInteractionEnabled = true
+        cell.roomStack.addGestureRecognizer(tapRoomListButton)
         return cell
     }
     
@@ -97,5 +103,10 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
         let roomCreationViewController = RoomCreationViewController()
         roomCreationViewController.modalPresentationStyle = .fullScreen
         present(roomCreationViewController, animated:  true, completion: nil)
+    }
+    
+    @objc func tapRoomListButton() {
+        let workingHistoryViewController = WorkingHistoryViewController()
+        navigationController?.pushViewController(workingHistoryViewController, animated: true)
     }
 }

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -74,6 +74,8 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if indexPath.section == 0 {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RoomCreationCell.identifier, for: indexPath) as! RoomCreationCell
+
+            cell.creationButton.addTarget(self, action: #selector(tapRoomCreationButton), for: .touchUpInside)
             return cell
         }
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RoomListCell.identifier, for: indexPath) as! RoomListCell
@@ -89,5 +91,11 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
+    }
+    
+    @objc func tapRoomCreationButton() {
+        let roomCreationViewController = RoomCreationViewController()
+        roomCreationViewController.modalPresentationStyle = .fullScreen
+        present(roomCreationViewController, animated:  true, completion: nil)
     }
 }

--- a/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
+++ b/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
@@ -30,10 +30,10 @@ class WorkingHistoryViewCell: UICollectionViewCell {
     }(UILabel())
     
     private let workTypeView: UIView = {
-          $0.backgroundColor = .purple
-          $0.layer.cornerRadius = 16
-          return $0
-      }(UIView())
+        $0.backgroundColor = .purple
+        $0.layer.cornerRadius = 16
+        return $0
+    }(UIView())
     
     let workType: UILabel = {
         $0.text = "철거"
@@ -55,6 +55,8 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         return $0
     }(UIStackView())
     
+    // MARK: - Init
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         layout()
@@ -64,14 +66,16 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         fatalError("init(coder:) 가 실행되지 않았습니다.")
     }
     
+    // MARK: - Method
+    
     private func layout() {
         addSubview(vStack)
-         vStack.addArrangedSubview(uiImageView)
-         uiImageView.addSubview(workTypeView)
-         workTypeView.addSubview(workType)
-         vStack.addArrangedSubview(imageDescription)
-
-         vStack.anchor(
+        vStack.addArrangedSubview(uiImageView)
+        uiImageView.addSubview(workTypeView)
+        workTypeView.addSubview(workType)
+        vStack.addArrangedSubview(imageDescription)
+        
+        vStack.anchor(
             top: topAnchor,
             left: leftAnchor,
             bottom: bottomAnchor,
@@ -81,30 +85,30 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         uiImageView.anchor(
             top: vStack.topAnchor,
             left: vStack.leftAnchor,
-             bottom: imageDescription.topAnchor,
-             right: vStack.rightAnchor
-         )
-
-         workTypeView.anchor(
-             top: uiImageView.topAnchor,
-             left: uiImageView.leftAnchor,
-             paddingTop: 8,
-             paddingLeft: 8
-         )
-
-         workType.anchor(
-             top: workTypeView.topAnchor,
-             left: workTypeView.leftAnchor,
-             bottom: workTypeView.bottomAnchor,
-             right: workTypeView.rightAnchor,
-             paddingTop: 8,
-             paddingLeft: 12,
-             paddingBottom: 8,
-             paddingRight: 12
-         )
-
-         imageDescription.anchor(
-             left: vStack.leftAnchor,
+            bottom: imageDescription.topAnchor,
+            right: vStack.rightAnchor
+        )
+        
+        workTypeView.anchor(
+            top: uiImageView.topAnchor,
+            left: uiImageView.leftAnchor,
+            paddingTop: 8,
+            paddingLeft: 8
+        )
+        
+        workType.anchor(
+            top: workTypeView.topAnchor,
+            left: workTypeView.leftAnchor,
+            bottom: workTypeView.bottomAnchor,
+            right: workTypeView.rightAnchor,
+            paddingTop: 8,
+            paddingLeft: 12,
+            paddingBottom: 8,
+            paddingRight: 12
+        )
+        
+        imageDescription.anchor(
+            left: vStack.leftAnchor,
             bottom: vStack.bottomAnchor,
             right: vStack.rightAnchor
         )

--- a/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
+++ b/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
@@ -29,9 +29,19 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         return $0
     }(UILabel())
     
-    private let workType: UIView = {
+    private let workTypeView: UIView = {
+        $0.backgroundColor = .purple
+        $0.layer.cornerRadius = 16
         return $0
     }(UIView())
+    
+    private let workType: UILabel = {
+        $0.text = "철거"
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.textAlignment = .center
+        $0.textColor = .white
+        return $0
+    }(UILabel())
     
     let vStack: UIStackView = {
         $0.backgroundColor = .white
@@ -57,6 +67,8 @@ class WorkingHistoryViewCell: UICollectionViewCell {
     private func layout() {
         addSubview(vStack)
         vStack.addArrangedSubview(uiImageView)
+        uiImageView.addSubview(workTypeView)
+        workTypeView.addSubview(workType)
         vStack.addArrangedSubview(imageDescription)
         
         vStack.anchor(
@@ -71,6 +83,24 @@ class WorkingHistoryViewCell: UICollectionViewCell {
             left: vStack.leftAnchor,
             bottom: imageDescription.topAnchor,
             right: vStack.rightAnchor
+        )
+
+        workTypeView.anchor(
+            top: uiImageView.topAnchor,
+            left: uiImageView.leftAnchor,
+            paddingTop: 8,
+            paddingLeft: 8
+        )
+
+        workType.anchor(
+            top: workTypeView.topAnchor,
+            left: workTypeView.leftAnchor,
+            bottom: workTypeView.bottomAnchor,
+            right: workTypeView.rightAnchor,
+            paddingTop: 8,
+            paddingLeft: 12,
+            paddingBottom: 8,
+            paddingRight: 12
         )
         
         imageDescription.anchor(

--- a/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
+++ b/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
@@ -30,10 +30,10 @@ class WorkingHistoryViewCell: UICollectionViewCell {
     }(UILabel())
     
     private let workTypeView: UIView = {
-        $0.backgroundColor = .purple
-        $0.layer.cornerRadius = 16
-        return $0
-    }(UIView())
+          $0.backgroundColor = .purple
+          $0.layer.cornerRadius = 16
+          return $0
+      }(UIView())
     
     let workType: UILabel = {
         $0.text = "철거"
@@ -66,12 +66,12 @@ class WorkingHistoryViewCell: UICollectionViewCell {
     
     private func layout() {
         addSubview(vStack)
-        vStack.addArrangedSubview(uiImageView)
-        uiImageView.addSubview(workTypeView)
-        workTypeView.addSubview(workType)
-        vStack.addArrangedSubview(imageDescription)
-        
-        vStack.anchor(
+         vStack.addArrangedSubview(uiImageView)
+         uiImageView.addSubview(workTypeView)
+         workTypeView.addSubview(workType)
+         vStack.addArrangedSubview(imageDescription)
+
+         vStack.anchor(
             top: topAnchor,
             left: leftAnchor,
             bottom: bottomAnchor,
@@ -81,30 +81,30 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         uiImageView.anchor(
             top: vStack.topAnchor,
             left: vStack.leftAnchor,
-            bottom: imageDescription.topAnchor,
-            right: vStack.rightAnchor
-        )
+             bottom: imageDescription.topAnchor,
+             right: vStack.rightAnchor
+         )
 
-        workTypeView.anchor(
-            top: uiImageView.topAnchor,
-            left: uiImageView.leftAnchor,
-            paddingTop: 8,
-            paddingLeft: 8
-        )
+         workTypeView.anchor(
+             top: uiImageView.topAnchor,
+             left: uiImageView.leftAnchor,
+             paddingTop: 8,
+             paddingLeft: 8
+         )
 
-        workType.anchor(
-            top: workTypeView.topAnchor,
-            left: workTypeView.leftAnchor,
-            bottom: workTypeView.bottomAnchor,
-            right: workTypeView.rightAnchor,
-            paddingTop: 8,
-            paddingLeft: 12,
-            paddingBottom: 8,
-            paddingRight: 12
-        )
-        
-        imageDescription.anchor(
-            left: vStack.leftAnchor,
+         workType.anchor(
+             top: workTypeView.topAnchor,
+             left: workTypeView.leftAnchor,
+             bottom: workTypeView.bottomAnchor,
+             right: workTypeView.rightAnchor,
+             paddingTop: 8,
+             paddingLeft: 12,
+             paddingBottom: 8,
+             paddingRight: 12
+         )
+
+         imageDescription.anchor(
+             left: vStack.leftAnchor,
             bottom: vStack.bottomAnchor,
             right: vStack.rightAnchor
         )

--- a/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
+++ b/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
@@ -35,7 +35,7 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         return $0
     }(UIView())
     
-    private let workType: UILabel = {
+    let workType: UILabel = {
         $0.text = "철거"
         $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         $0.textAlignment = .center

--- a/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
+++ b/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
@@ -33,7 +33,7 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         return $0
     }(UIView())
     
-    private let vStack: UIStackView = {
+    let vStack: UIStackView = {
         $0.backgroundColor = .white
         $0.axis = .vertical
         $0.layer.masksToBounds = false

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -113,6 +113,9 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         cell.imageDescription.textAlignment = .center
         cell.imageDescription.font = UIFont.systemFont(ofSize: 16, weight: .regular)
         
+        let tapContents = UITapGestureRecognizer(target: self, action: #selector(tapContents))
+        cell.vStack.addGestureRecognizer(tapContents)
+        
         return cell
     }
     
@@ -121,5 +124,10 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         let cellHeight = width / 4 * 3 + 30
         
         return CGSize(width: Int(width), height: Int(cellHeight))
+    }
+    
+    @objc func tapContents() {
+        let detailViewController = DetailViewController()
+        navigationController?.pushViewController(detailViewController, animated: true)
     }
 }

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -38,9 +38,7 @@ class WorkingHistoryViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
-        
-        navigationController?.navigationBar.topItem?.title = "포항공대 포스빌"
-        navigationController?.navigationBar.prefersLargeTitles = false
+        setNavigationBar()
         
         workingHistoryView.delegate = self
         workingHistoryView.dataSource = self
@@ -72,8 +70,15 @@ class WorkingHistoryViewController: UIViewController {
         )
     }
     
-    // TODO: - postingCategoryView를 FullScreen모달로 띄우는 기능. 추후 수정
+    // MARK: - Method
     
+    private func setNavigationBar() {
+        navigationItem.title = "포항공대 포스빌"
+        navigationController?.navigationBar.prefersLargeTitles = false
+    }
+    
+    // TODO: - postingCategoryView를 FullScreen모달로 띄우는 기능. 추후 수정
+
     @objc func tapWritingButton() {
         let postingCategoryView = ViewController()
         postingCategoryView.modalPresentationStyle = .fullScreen

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -118,6 +118,9 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         cell.imageDescription.textAlignment = .center
         cell.imageDescription.font = UIFont.systemFont(ofSize: 16, weight: .regular)
         
+        let tapContents = UITapGestureRecognizer(target: self, action: #selector(tapContents))
+        cell.vStack.addGestureRecognizer(tapContents)
+        
         return cell
     }
     
@@ -126,5 +129,10 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         let cellHeight = width / 4 * 3 + 30
         
         return CGSize(width: Int(width), height: Int(cellHeight))
+    }
+    
+    @objc func tapContents() {
+        let detailViewController = DetailViewController()
+        navigationController?.pushViewController(detailViewController, animated: true)
     }
 }

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -112,6 +112,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         cell.imageDescription.text = "애플, 동아시아 최초 '디벨로퍼 아카데미' 한국서 운영"
         cell.imageDescription.textAlignment = .center
         cell.imageDescription.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        cell.workType.text = "철거"
         
         let tapContents = UITapGestureRecognizer(target: self, action: #selector(tapContents))
         cell.vStack.addGestureRecognizer(tapContents)

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -117,6 +117,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         cell.imageDescription.text = "애플, 동아시아 최초 '디벨로퍼 아카데미' 한국서 운영"
         cell.imageDescription.textAlignment = .center
         cell.imageDescription.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        cell.workType.text = "철거"
         
         let tapContents = UITapGestureRecognizer(target: self, action: #selector(tapContents))
         cell.vStack.addGestureRecognizer(tapContents)


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 시공내용의 이미지 및 설명 클릭 시 해당 세부내용으로 이동하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- Navigation
- 컨텐츠(이미지, 설명) 타입(철거) 추가

## ToDo 📆 (남은 작업)
- [ ] 없음.

## ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/98405970/197351636-6d64530d-36a9-4539-b11f-8ae81fb8aace.mp4

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 코드입니다. 가볍게 확인하시면 되겠습니다.

## Close Issues 🔒 (닫을 Issue)
Close #10 .
