### PR TITLE
[Feature] 방생성뷰 FullScreen Dismiss 기능 추가

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -18,10 +18,10 @@
 		26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */; };
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
-		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */; };
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
+		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */; };
 		98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */; };
 		98C0D06428FCE99300E0E439 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06328FCE99300E0E439 /* JSON.swift */; };
@@ -47,10 +47,10 @@
 		26E3749D28FE95D100997DA7 /* Samsam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Samsam.entitlements; sourceTree = "<group>"; };
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
-		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingCategoryViewController.swift; sourceTree = "<group>"; };
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
+		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationViewContoller.swift; sourceTree = "<group>"; };
 		98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayout+.swift"; sourceTree = "<group>"; };
 		98C0D06328FCE99300E0E439 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
@@ -144,8 +144,8 @@
 			children = (
 				26E3748528FCDC0000997DA7 /* ViewController.swift */,
 				26E3749528FCF56400997DA7 /* RoomListViewController.swift */,
-				26E3749728FD2D0700997DA7 /* RoomListCell.swift */,
 				26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */,
+				26E3749728FD2D0700997DA7 /* RoomListCell.swift */,
 				98C0D06D28FCF46A00E0E439 /* WorkingHistoryView */,
 				26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */,
 				26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */,

--- a/Samsam/ViewController/RoomCreationCell.swift
+++ b/Samsam/ViewController/RoomCreationCell.swift
@@ -15,7 +15,7 @@ class RoomCreationCell: UICollectionViewCell {
     
     // MARK: - View
     
-    private let creationButton: UIButton = {
+    let creationButton: UIButton = {
         $0.setImage(UIImage(systemName: "plus"), for: .normal)
         $0.tintColor = .black
         $0.setTitle("고객 추가하기", for: .normal)

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -24,16 +24,13 @@ class RoomCreationViewController: UIViewController {
         return $0
     }(UIStackView())
     
-    private let closeButton: UILabel = {
-        let attributedString = NSMutableAttributedString(string: "")
-        let imageTransition = NSTextAttachment()
-        imageTransition.image = UIImage(systemName: "xmark")
-        attributedString.append(NSMutableAttributedString(attachment: imageTransition))
-        $0.attributedText = attributedString
+    private let closeButton: UIButton = {
+        $0.setImage(UIImage(systemName: "xmark"), for: .normal)
+        $0.contentHorizontalAlignment = .left
         $0.tintColor = .black
         $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
         return $0
-    }(UILabel())
+    }(UIButton())
     
     private let viewTitle: UILabel = {
         $0.text = "방 생성"
@@ -160,7 +157,7 @@ class RoomCreationViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
-        setCloseButton()
+        closeButton.addTarget(self, action: #selector(tapCloseButton), for: .touchUpInside)
         nextButton.addTarget(self, action: #selector(tapNextButton), for: .touchUpInside)
     }
     
@@ -262,12 +259,6 @@ class RoomCreationViewController: UIViewController {
             right: uiView.rightAnchor,
             height: 50
         )
-    }
-    
-    private func setCloseButton() {
-        let tapCloseButton = UITapGestureRecognizer(target: self, action: #selector(tapCloseButton))
-        self.closeButton.isUserInteractionEnabled = true
-        self.closeButton.addGestureRecognizer(tapCloseButton)
     }
     
     @objc private func tapStepper() {

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -19,6 +19,36 @@ class RoomCreationViewController: UIViewController {
         return $0
     }(UIView())
     
+    private let titleHstack: UIStackView = {
+        $0.axis = .horizontal
+        return $0
+    }(UIStackView())
+    
+    private let closeButton: UILabel = {
+        let attributedString = NSMutableAttributedString(string: "")
+        let imageTransition = NSTextAttachment()
+        imageTransition.image = UIImage(systemName: "xmark")
+        attributedString.append(NSMutableAttributedString(attachment: imageTransition))
+        $0.attributedText = attributedString
+        $0.tintColor = .black
+        $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
+        return $0
+    }(UILabel())
+    
+    private let viewTitle: UILabel = {
+        $0.text = "방 생성"
+        $0.textColor = .black
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
+        return $0
+    }(UILabel())
+    
+    private let spacer: UIView = {
+        $0.setWidth(width: (UIScreen.main.bounds.width - 32) / 3)
+        return $0
+    }(UIView())
+    
     private let customerTitle: UILabel = {
         $0.text = "고객명/주소"
         $0.textAlignment = .left
@@ -130,12 +160,18 @@ class RoomCreationViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
-        setNavigationbar()
+        setCloseButton()
         nextButton.addTarget(self, action: #selector(tapNextButton), for: .touchUpInside)
     }
     
     private func layout() {
         view.addSubview(uiView)
+        
+        uiView.addSubview(titleHstack)
+        titleHstack.addArrangedSubview(closeButton)
+        titleHstack.addArrangedSubview(viewTitle)
+        titleHstack.addArrangedSubview(spacer)
+        
         uiView.addSubview(customerTitle)
         uiView.addSubview(customerTextField)
         uiView.addSubview(textUnderLine)
@@ -160,14 +196,21 @@ class RoomCreationViewController: UIViewController {
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingTop: 40,
+            paddingTop: 10,
             paddingLeft: 16,
             paddingBottom: 16,
             paddingRight: 16
         )
         
-        customerTitle.anchor(
+        titleHstack.anchor(
             top: uiView.topAnchor,
+            left: uiView.leftAnchor,
+            bottom: customerTitle.topAnchor,
+            right: uiView.rightAnchor,
+            paddingBottom: 40
+        )
+        
+        customerTitle.anchor(
             left: uiView.leftAnchor,
             bottom: customerTextField.topAnchor,
             right: uiView.rightAnchor,
@@ -221,13 +264,10 @@ class RoomCreationViewController: UIViewController {
         )
     }
     
-    private func setNavigationbar() {
-        let appearance = UINavigationBarAppearance()
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.topItem?.title = "방 생성"
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.setNavigationBarHidden(false, animated: true)
+    private func setCloseButton() {
+        let tapCloseButton = UITapGestureRecognizer(target: self, action: #selector(tapCloseButton))
+        self.closeButton.isUserInteractionEnabled = true
+        self.closeButton.addGestureRecognizer(tapCloseButton)
     }
     
     @objc private func tapStepper() {
@@ -240,5 +280,9 @@ class RoomCreationViewController: UIViewController {
     @objc private func tapNextButton() {
         let VC = ViewController()
         navigationController?.pushViewController(VC, animated: true)
+    }
+    
+    @objc private func tapCloseButton() {
+        self.dismiss(animated: true)
     }
 }

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -74,6 +74,8 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if indexPath.section == 0 {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RoomCreationCell.identifier, for: indexPath) as! RoomCreationCell
+
+            cell.creationButton.addTarget(self, action: #selector(tapRoomCreationButton), for: .touchUpInside)
             return cell
         }
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RoomListCell.identifier, for: indexPath) as! RoomListCell
@@ -89,5 +91,11 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
+    }
+    
+    @objc func tapRoomCreationButton() {
+        let roomCreationViewController = RoomCreationViewController()
+        roomCreationViewController.modalPresentationStyle = .fullScreen
+        present(roomCreationViewController, animated:  true, completion: nil)
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 방생성뷰 풀스크린 모달 생성 및 닫기 기능 추가
- 모달 상태에서 navigationItem이 나타나지 않음

## Key Changes 🔥 (주요 구현/변경 사항)
- 방 생성하기 버튼 클릭 시 FullScreen 띄우는 코드 생성
- FullScreen에 NavigationItem이 나타나지 않아 setNavigationCode 삭제
- NavigationItem 대신 별도의 Label추가
- FullScreen Dismiss기능 추가

## ToDo 📆 (남은 작업)
- [ ] nextButton 대상 뷰 수정

## ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/98405970/197396646-a41e6888-3d10-442e-8861-47969b0cb406.mp4

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- NavigationItem을 Modal에 띄우는 방법이 별도로 있을까요? 아이폰 기본 문자의 문자작성 기능에는 Modal에도 타이들이 있습니다.

## Reference 🔗
- Label에 이미지 추가 참고자료:  https://zeddios.tistory.com/406

## Close Issues 🔒 (닫을 Issue)
Close #49 .
