### PR TITLE
[Feature] 방 목록 뷰에서 네비게이션 이동

### DIFF
--- a/Samsam/ViewController/RoomListCell.swift
+++ b/Samsam/ViewController/RoomListCell.swift
@@ -20,7 +20,7 @@ class RoomListCell: UICollectionViewCell {
         return $0
     }(UIStackView())
     
-    private let roomStack: UIStackView = {
+    let roomStack: UIStackView = {
         $0.axis = .horizontal
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 16

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -45,7 +45,9 @@ class RoomListViewController: UIViewController {
     }
     
     private func setupNavigationTitle() {
-        navigationController?.navigationBar.topItem?.title = "앱 이름"
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        navigationItem.backBarButtonItem = backBarButtonItem
+        navigationItem.title = "앱 이름"
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
@@ -79,6 +81,10 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
             return cell
         }
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RoomListCell.identifier, for: indexPath) as! RoomListCell
+        
+        let tapRoomListButton = UITapGestureRecognizer(target: self, action: #selector(tapRoomListButton))
+        cell.roomStack.isUserInteractionEnabled = true
+        cell.roomStack.addGestureRecognizer(tapRoomListButton)
         return cell
     }
     
@@ -97,5 +103,10 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
         let roomCreationViewController = RoomCreationViewController()
         roomCreationViewController.modalPresentationStyle = .fullScreen
         present(roomCreationViewController, animated:  true, completion: nil)
+    }
+    
+    @objc func tapRoomListButton() {
+        let workingHistoryViewController = WorkingHistoryViewController()
+        navigationController?.pushViewController(workingHistoryViewController, animated: true)
     }
 }

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -38,9 +38,7 @@ class WorkingHistoryViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
-        
-        navigationController?.navigationBar.topItem?.title = "포항공대 포스빌"
-        navigationController?.navigationBar.prefersLargeTitles = false
+        setNavigationBar()
         
         workingHistoryView.delegate = self
         workingHistoryView.dataSource = self
@@ -72,8 +70,15 @@ class WorkingHistoryViewController: UIViewController {
         )
     }
     
-    // TODO: - postingCategoryView를 FullScreen모달로 띄우는 기능. 추후 수정
+    // MARK: - Method
     
+    private func setNavigationBar() {
+        navigationItem.title = "포항공대 포스빌"
+        navigationController?.navigationBar.prefersLargeTitles = false
+    }
+    
+    // TODO: - postingCategoryView를 FullScreen모달로 띄우는 기능. 추후 수정
+
     @objc func tapWritingButton() {
         let postingCategoryView = ViewController()
         postingCategoryView.modalPresentationStyle = .fullScreen


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- navigationViewController.navigationbar.topitem.title은 다음 뷰의 네비게이션 타이틀을 이전 뷰 타이틀에 그대로 반영하는 문제가 있어 코드 일부 수정.

## Key Changes 🔥 (주요 구현/변경 사항)
- navigation
- BackButton 내용 지우기. (이전 뷰 이름이 나오는 것 삭제)

## ToDo 📆 (남은 작업)
- [ ] 초대코드 공유 버튼 생성
- [ ] 초대코드 공유 기능 추가

## ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/98405970/197405387-e593ed40-0246-49fb-bf26-0b8a1d42a8b9.mp4

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 코드입니다. 가볍게 확인하시면 될 것 같습니다.

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #27 .
