### PR TITLE
[Feature] CoreData 추가

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -19,6 +19,16 @@
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
 		26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */; };
+		26FEC1D92902E6F2006C410B /* CategoryEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1CF2902E6F2006C410B /* CategoryEntity+CoreDataClass.swift */; };
+		26FEC1DA2902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D02902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift */; };
+		26FEC1DB2902E6F2006C410B /* PostingEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D12902E6F2006C410B /* PostingEntity+CoreDataClass.swift */; };
+		26FEC1DC2902E6F2006C410B /* PostingEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D22902E6F2006C410B /* PostingEntity+CoreDataProperties.swift */; };
+		26FEC1DD2902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D32902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift */; };
+		26FEC1DE2902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D42902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift */; };
+		26FEC1DF2902E6F2006C410B /* PhotoEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D52902E6F2006C410B /* PhotoEntity+CoreDataClass.swift */; };
+		26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */; };
+		26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */; };
+		26FEC1E22902E6F2006C410B /* RoomEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
 		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
@@ -53,6 +63,16 @@
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
 		26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DataTable.xcdatamodel; sourceTree = "<group>"; };
+		26FEC1CF2902E6F2006C410B /* CategoryEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D02902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategoryEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D12902E6F2006C410B /* PostingEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostingEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D22902E6F2006C410B /* PostingEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostingEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D32902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkingStatusEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D42902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkingStatusEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D52902E6F2006C410B /* PhotoEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotoEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotoEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
+		26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
 		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
@@ -119,6 +139,16 @@
 		26FEC1BA2902D87E006C410B /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				26FEC1CF2902E6F2006C410B /* CategoryEntity+CoreDataClass.swift */,
+				26FEC1D02902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift */,
+				26FEC1D12902E6F2006C410B /* PostingEntity+CoreDataClass.swift */,
+				26FEC1D22902E6F2006C410B /* PostingEntity+CoreDataProperties.swift */,
+				26FEC1D32902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift */,
+				26FEC1D42902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift */,
+				26FEC1D52902E6F2006C410B /* PhotoEntity+CoreDataClass.swift */,
+				26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */,
+				26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */,
+				26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */,
 				26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */,
 			);
 			path = CoreData;
@@ -294,30 +324,40 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26FEC1DB2902E6F2006C410B /* PostingEntity+CoreDataClass.swift in Sources */,
 				26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */,
 				980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */,
 				26E3748628FCDC0000997DA7 /* ViewController.swift in Sources */,
 				98C0D06C28FCF46500E0E439 /* WorkingHistoryViewController.swift in Sources */,
+				26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */,
 				98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */,
 				98C2448B28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift in Sources */,
 				98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */,
 				26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */,
 				26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */,
 				98C0D06428FCE99300E0E439 /* JSON.swift in Sources */,
+				26FEC1DA2902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift in Sources */,
+				26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */,
 				98C0D06A28FCEA4900E0E439 /* ImagePicker.swift in Sources */,
 				43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */,
+				26FEC1DC2902E6F2006C410B /* PostingEntity+CoreDataProperties.swift in Sources */,
 				26E3748228FCDC0000997DA7 /* AppDelegate.swift in Sources */,
 				43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */,
+				26FEC1DE2902E6F2006C410B /* WorkingStatusEntity+CoreDataProperties.swift in Sources */,
 				26E3748428FCDC0000997DA7 /* SceneDelegate.swift in Sources */,
 				98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */,
 				4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */,
 				43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */,
+				26FEC1DD2902E6F2006C410B /* WorkingStatusEntity+CoreDataClass.swift in Sources */,
 				26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */,
 				98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */,
 				26E3749628FCF56400997DA7 /* RoomListViewController.swift in Sources */,
 				26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */,
 				43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */,
+				26FEC1D92902E6F2006C410B /* CategoryEntity+CoreDataClass.swift in Sources */,
 				4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */,
+				26FEC1DF2902E6F2006C410B /* PhotoEntity+CoreDataClass.swift in Sources */,
+				26FEC1E22902E6F2006C410B /* RoomEntity+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */; };
 		26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */; };
 		26FEC1E22902E6F2006C410B /* RoomEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */; };
+		26FEC1E4290466F2006C410B /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1E3290466F2006C410B /* CoreDataManager.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
 		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
@@ -73,6 +74,7 @@
 		26FEC1D62902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhotoEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoomEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		26FEC1E3290466F2006C410B /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
 		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				26FEC1D72902E6F2006C410B /* RoomEntity+CoreDataClass.swift */,
 				26FEC1D82902E6F2006C410B /* RoomEntity+CoreDataProperties.swift */,
 				26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */,
+				26FEC1E3290466F2006C410B /* CoreDataManager.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -335,6 +338,7 @@
 				98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */,
 				26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */,
 				26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */,
+				26FEC1E4290466F2006C410B /* CoreDataManager.swift in Sources */,
 				98C0D06428FCE99300E0E439 /* JSON.swift in Sources */,
 				26FEC1DA2902E6F2006C410B /* CategoryEntity+CoreDataProperties.swift in Sources */,
 				26FEC1E12902E6F2006C410B /* RoomEntity+CoreDataClass.swift in Sources */,

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */; };
 		26E3749F28FE9DA300997DA7 /* PhoneNumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */; };
 		26FEC1B628FFF52D006C410B /* RoomCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */; };
+		26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
 		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
@@ -51,6 +52,7 @@
 		26E3749D28FE95D100997DA7 /* Samsam.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Samsam.entitlements; sourceTree = "<group>"; };
 		26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumViewController.swift; sourceTree = "<group>"; };
 		26FEC1B528FFF52D006C410B /* RoomCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationCell.swift; sourceTree = "<group>"; };
+		26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DataTable.xcdatamodel; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
 		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				26E3749D28FE95D100997DA7 /* Samsam.entitlements */,
+				26FEC1BA2902D87E006C410B /* CoreData */,
 				98C0D05D28FCE8C300E0E439 /* Global */,
 				98C0D06128FCE8FA00E0E439 /* ViewController */,
 				98C0D06528FCE9C700E0E439 /* Model */,
@@ -111,6 +114,14 @@
 				26E3748F28FCDC0100997DA7 /* Info.plist */,
 			);
 			path = Samsam;
+			sourceTree = "<group>";
+		};
+		26FEC1BA2902D87E006C410B /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */,
+			);
+			path = CoreData;
 			sourceTree = "<group>";
 		};
 		980D900C28FE6705003CC2DA /* DetailView */ = {
@@ -291,6 +302,7 @@
 				98C2448B28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift in Sources */,
 				98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */,
 				26E3749828FD2D0700997DA7 /* RoomListCell.swift in Sources */,
+				26FEC1B92902D85A006C410B /* DataTable.xcdatamodeld in Sources */,
 				98C0D06428FCE99300E0E439 /* JSON.swift in Sources */,
 				98C0D06A28FCEA4900E0E439 /* ImagePicker.swift in Sources */,
 				43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */,
@@ -531,6 +543,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		26FEC1B72902D85A006C410B /* DataTable.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */,
+			);
+			currentVersion = 26FEC1B82902D85A006C410B /* DataTable.xcdatamodel */;
+			path = DataTable.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 26E3747628FCDC0000997DA7 /* Project object */;
 }

--- a/Samsam/CoreData/CategoryEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/CategoryEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  CategoryEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(CategoryEntity)
+public class CategoryEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/CategoryEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/CategoryEntity+CoreDataProperties.swift
@@ -1,0 +1,62 @@
+//
+//  CategoryEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension CategoryEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CategoryEntity> {
+        return NSFetchRequest<CategoryEntity>(entityName: "CategoryEntity")
+    }
+
+    @NSManaged public var categoryID: Int32
+    @NSManaged public var categoryName: String?
+    @NSManaged public var categoryToWorkingStatus: NSSet?
+    @NSManaged public var categoryToPosting: NSSet?
+
+}
+
+// MARK: Generated accessors for categoryToWorkingStatus
+extension CategoryEntity {
+
+    @objc(addCategoryToWorkingStatusObject:)
+    @NSManaged public func addToCategoryToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(removeCategoryToWorkingStatusObject:)
+    @NSManaged public func removeFromCategoryToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(addCategoryToWorkingStatus:)
+    @NSManaged public func addToCategoryToWorkingStatus(_ values: NSSet)
+
+    @objc(removeCategoryToWorkingStatus:)
+    @NSManaged public func removeFromCategoryToWorkingStatus(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for categoryToPosting
+extension CategoryEntity {
+
+    @objc(addCategoryToPostingObject:)
+    @NSManaged public func addToCategoryToPosting(_ value: PostingEntity)
+
+    @objc(removeCategoryToPostingObject:)
+    @NSManaged public func removeFromCategoryToPosting(_ value: PostingEntity)
+
+    @objc(addCategoryToPosting:)
+    @NSManaged public func addToCategoryToPosting(_ values: NSSet)
+
+    @objc(removeCategoryToPosting:)
+    @NSManaged public func removeFromCategoryToPosting(_ values: NSSet)
+
+}
+
+extension CategoryEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -1,0 +1,26 @@
+//
+//  CoreDataManager.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/23.
+//
+
+import CoreData
+import Foundation
+import UIKit
+class CoreDataManager {
+    
+    // MARK: - Property
+    
+    // MARK: - Save Method
+    
+    
+    // MARK: - Update Method
+    
+    
+    // MARK: - Load Method
+    
+    
+    // MARK: - Count Method
+    
+}

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -228,6 +228,23 @@ class CoreDataManager {
         }
     }
     
+    func loadOneRoomData(roomID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        do {
+            let room = try context.fetch(RoomEntity.fetchRequest()) as! [RoomEntity]
+            
+            room.forEach {
+                if $0.roomID == roomID {
+                    oneRoom = $0
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -65,6 +65,8 @@ enum Category: Int {
     }
 }
 
+let coreDataManager = CoreDataManager()
+
 class CoreDataManager {
     
     // MARK: - Property

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -167,6 +167,22 @@ class CoreDataManager {
     
     // MARK: - Update Method
     
+    func updateRoomData(room: RoomEntity, clientName: String, startDate: Date, endDate: Date, warrantyTime: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        room.clientName = clientName
+        room.startDate = startDate
+        room.endDate = endDate
+        room.warrantyTime = Int32(warrantyTime)
+        
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Load Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -145,6 +145,25 @@ class CoreDataManager {
         }
     }
     
+    func createPhotoData(postingID: Int, photoPath: Data) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let photoEntity = NSEntityDescription.entity(forEntityName: "PhotoEntity", in: context)
+        
+        if let photoEntity = photoEntity {
+            let photo = NSManagedObject(entity: photoEntity, insertInto: context)
+            photo.setValue(coreDataManager.countData(dataType: "photo"), forKey: "photoID")
+            photo.setValue(postingID, forKey: "postingID")
+            photo.setValue(photoPath, forKey: "photoPath")
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
     
     // MARK: - Update Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -76,7 +76,30 @@ class CoreDataManager {
     
     @Published var oneRoom: RoomEntity?
     
-    // MARK: - Save Method
+    // MARK: - Create Method
+    
+    func createRoomData(clientName: String, startDate: Date, endDate: Date, warrantyTime: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let roomEntity = NSEntityDescription.entity(forEntityName: "RoomEntity", in: context)
+        
+        if let roomEntity = roomEntity {
+            let room = NSManagedObject(entity: roomEntity, insertInto: context)
+            room.setValue(coreDataManager.countData(dataType: "room"), forKey: "roomID")
+            room.setValue(clientName, forKey: "clientName")
+            room.setValue(startDate, forKey: "startDate")
+            room.setValue(endDate, forKey: "endDate")
+            room.setValue(warrantyTime, forKey: "warrantyTime")
+            // 방상태 어떻게 하더라?
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
     
     
     // MARK: - Update Method

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -183,6 +183,19 @@ class CoreDataManager {
         }
     }
     
+    func updateWorkingStatusData(workingStatus: WorkingStatusEntity, status: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        workingStatus.status = Int32(status)
+        
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Load Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -93,7 +93,6 @@ class CoreDataManager {
             room.setValue(startDate, forKey: "startDate")
             room.setValue(endDate, forKey: "endDate")
             room.setValue(warrantyTime, forKey: "warrantyTime")
-            // 방상태 어떻게 하더라?
             
             do {
                 try context.save()

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -245,6 +245,25 @@ class CoreDataManager {
         }
     }
     
+    func loadWorkingStatusData(roomID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        workingStatuses = [WorkingStatusEntity]()
+        
+        do {
+            let workingStatus = try context.fetch(WorkingStatusEntity.fetchRequest()) as! [WorkingStatusEntity]
+            
+            workingStatus.forEach {
+                if $0.roomID == roomID {
+                    workingStatuses.append($0)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -283,6 +283,24 @@ class CoreDataManager {
         }
     }
     
+    func loadPhotoData(postingID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        photos = [PhotoEntity]()
+        
+        do {
+            let photo = try context.fetch(PhotoEntity.fetchRequest()) as! [PhotoEntity]
+            
+            photo.forEach {
+                if $0.postingID == postingID {
+                    photos.append($0)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -304,4 +304,26 @@ class CoreDataManager {
     
     // MARK: - Count Method
     
+    func countData(dataType: String) -> Int {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        do {
+            switch(dataType) {
+            case "room":
+                return try context.fetch(RoomEntity.fetchRequest()).count
+            case "workingStatus":
+                return try context.fetch(WorkingStatusEntity.fetchRequest()).count
+            case "posting":
+                return try context.fetch(PostingEntity.fetchRequest()).count
+            case "photo":
+                return try context.fetch(PhotoEntity.fetchRequest()).count
+            default:
+                return 0
+            }
+        } catch {
+            print(error.localizedDescription)
+            return 0
+        }
+    }
 }

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -69,6 +69,13 @@ class CoreDataManager {
     
     // MARK: - Property
     
+    @Published var rooms = [RoomEntity]()
+    @Published var workingStatuses = [WorkingStatusEntity]()
+    @Published var postings = [PostingEntity]()
+    @Published var photos = [PhotoEntity]()
+    
+    @Published var oneRoom: RoomEntity?
+    
     // MARK: - Save Method
     
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -196,6 +196,18 @@ class CoreDataManager {
         }
     }
     
+    func updatePostingData(posting: PostingEntity, explanation: String) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        posting.explanation = explanation
+        
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
     
     // MARK: - Load Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -123,6 +123,28 @@ class CoreDataManager {
         }
     }
     
+    func createPostingData(roomID: Int, categoryID: Int, explanation: String) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let postingEntity = NSEntityDescription.entity(forEntityName: "PostingEntity", in: context)
+        
+        if let postingEntity = postingEntity {
+            let posting = NSManagedObject(entity: postingEntity, insertInto: context)
+            posting.setValue(coreDataManager.countData(dataType: "posting"), forKey: "postingID")
+            posting.setValue(roomID, forKey: "roomID")
+            posting.setValue(categoryID, forKey: "categoryID")
+            posting.setValue(explanation, forKey: "explanation")
+            posting.setValue(Date(), forKey: "createDate")
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
     
     // MARK: - Update Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -8,6 +8,63 @@
 import CoreData
 import Foundation
 import UIKit
+
+enum Category: Int {
+    case zero = 0
+    case one = 1
+    case two = 2
+    case three = 3
+    case four = 4
+    case five = 5
+    case six = 6
+    case seven = 7
+    case eight = 8
+    case nine = 9
+    case ten = 10
+    case eleven = 11
+    case twelve = 12
+    case thirteen = 13
+    case fourteen = 14
+    case fifteen = 15
+    
+    func categoryName() -> String {
+        switch self {
+        case .zero:
+            return "실측"
+        case .one:
+            return "철거"
+        case .two:
+            return "설비"
+        case .three:
+            return "새시"
+        case .four:
+            return "목공"
+        case .five:
+            return "전기"
+        case .six:
+            return "페인트"
+        case .seven:
+            return "필름"
+        case .eight:
+            return "타일"
+        case .nine:
+            return "욕실"
+        case .ten:
+            return "마루"
+        case .eleven:
+            return "도배"
+        case .twelve:
+            return "주방"
+        case .thirteen:
+            return "폴딩도어"
+        case .fourteen:
+            return "조명"
+        case .fifteen:
+            return "기타"
+        }
+    }
+}
+
 class CoreDataManager {
     
     // MARK: - Property

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -101,6 +101,28 @@ class CoreDataManager {
         }
     }
     
+    func createWorkingStatusData(roomID: Int, categoryID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let workingStatusEntity = NSEntityDescription.entity(forEntityName: "WorkingStatusEntity", in: context)
+        
+        if let workingStatusEntity = workingStatusEntity {
+            let workingStatus = NSManagedObject(entity: workingStatusEntity, insertInto: context)
+            workingStatus.setValue(coreDataManager.countData(dataType: "workingStatus"), forKey: "statusID")
+            workingStatus.setValue(roomID, forKey: "roomID")
+            workingStatus.setValue(categoryID, forKey: "categoryID")
+            workingStatus.setValue(0, forKey: "status")
+            // 0: 시작안함, 1: 진행중, 2: 완료, 3: 삭제
+            
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
     
     // MARK: - Update Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -264,6 +264,25 @@ class CoreDataManager {
         }
     }
     
+    func loadPostingData(roomID: Int) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        postings = [PostingEntity]()
+        
+        do {
+            let posting = try context.fetch(PostingEntity.fetchRequest()) as! [PostingEntity]
+            
+            posting.forEach {
+                if $0.roomID == roomID {
+                    postings.append($0)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/CoreDataManager.swift
+++ b/Samsam/CoreData/CoreDataManager.swift
@@ -211,6 +211,23 @@ class CoreDataManager {
     
     // MARK: - Load Method
     
+    func loadAllRoomData() {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        rooms = [RoomEntity]()
+        
+        do {
+            let room = try context.fetch(RoomEntity.fetchRequest()) as! [RoomEntity]
+            
+            room.forEach {
+                rooms.append($0)
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
     
     // MARK: - Count Method
     

--- a/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
+++ b/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
@@ -25,7 +25,6 @@
     <entity name="RoomEntity" representedClassName="RoomEntity" syncable="YES">
         <attribute name="clientName" optional="YES" attributeType="String"/>
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="inviteCode" optional="YES" attributeType="String"/>
         <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="warrantyTime" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
+++ b/Samsam/CoreData/DataTable.xcdatamodeld/DataTable.xcdatamodel/contents
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CategoryEntity" representedClassName="CategoryEntity" syncable="YES">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="categoryName" optional="YES" attributeType="String"/>
+        <relationship name="categoryToPosting" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PostingEntity" inverseName="postingToCategory" inverseEntity="PostingEntity"/>
+        <relationship name="categoryToWorkingStatus" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WorkingStatusEntity" inverseName="workingStatusToCategory" inverseEntity="WorkingStatusEntity"/>
+    </entity>
+    <entity name="PhotoEntity" representedClassName="PhotoEntity" syncable="YES">
+        <attribute name="photoID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="photoPath" optional="YES" attributeType="Binary"/>
+        <attribute name="postingID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="photoToPosting" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PostingEntity" inverseName="postingToPhoto" inverseEntity="PostingEntity"/>
+    </entity>
+    <entity name="PostingEntity" representedClassName="PostingEntity" syncable="YES">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="explanation" optional="YES" attributeType="String"/>
+        <attribute name="postingID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="postingToCategory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CategoryEntity" inverseName="categoryToPosting" inverseEntity="CategoryEntity"/>
+        <relationship name="postingToPhoto" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PhotoEntity" inverseName="photoToPosting" inverseEntity="PhotoEntity"/>
+        <relationship name="postingToRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RoomEntity" inverseName="roomToPosting" inverseEntity="RoomEntity"/>
+    </entity>
+    <entity name="RoomEntity" representedClassName="RoomEntity" syncable="YES">
+        <attribute name="clientName" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="inviteCode" optional="YES" attributeType="String"/>
+        <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="warrantyTime" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="roomToPosting" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PostingEntity" inverseName="postingToRoom" inverseEntity="PostingEntity"/>
+        <relationship name="roomToWorkingStatus" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WorkingStatusEntity" inverseName="workingStatusToRoom" inverseEntity="WorkingStatusEntity"/>
+    </entity>
+    <entity name="WorkingStatusEntity" representedClassName="WorkingStatusEntity" syncable="YES">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="roomID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="workingStatusToCategory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CategoryEntity" inverseName="categoryToWorkingStatus" inverseEntity="CategoryEntity"/>
+        <relationship name="workingStatusToRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RoomEntity" inverseName="roomToWorkingStatus" inverseEntity="RoomEntity"/>
+    </entity>
+</model>

--- a/Samsam/CoreData/PhotoEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/PhotoEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  PhotoEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(PhotoEntity)
+public class PhotoEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/PhotoEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/PhotoEntity+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  PhotoEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension PhotoEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<PhotoEntity> {
+        return NSFetchRequest<PhotoEntity>(entityName: "PhotoEntity")
+    }
+
+    @NSManaged public var photoID: Int32
+    @NSManaged public var photoPath: Data?
+    @NSManaged public var postingID: Int32
+    @NSManaged public var photoToPosting: PostingEntity?
+
+}
+
+extension PhotoEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/PostingEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/PostingEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  PostingEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(PostingEntity)
+public class PostingEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/PostingEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/PostingEntity+CoreDataProperties.swift
@@ -1,0 +1,49 @@
+//
+//  PostingEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension PostingEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<PostingEntity> {
+        return NSFetchRequest<PostingEntity>(entityName: "PostingEntity")
+    }
+
+    @NSManaged public var categoryID: Int32
+    @NSManaged public var createDate: Date?
+    @NSManaged public var explanation: String?
+    @NSManaged public var postingID: Int32
+    @NSManaged public var roomID: Int32
+    @NSManaged public var postingToCategory: CategoryEntity?
+    @NSManaged public var postingToRoom: RoomEntity?
+    @NSManaged public var postingToPhoto: NSSet?
+
+}
+
+// MARK: Generated accessors for postingToPhoto
+extension PostingEntity {
+
+    @objc(addPostingToPhotoObject:)
+    @NSManaged public func addToPostingToPhoto(_ value: PhotoEntity)
+
+    @objc(removePostingToPhotoObject:)
+    @NSManaged public func removeFromPostingToPhoto(_ value: PhotoEntity)
+
+    @objc(addPostingToPhoto:)
+    @NSManaged public func addToPostingToPhoto(_ values: NSSet)
+
+    @objc(removePostingToPhoto:)
+    @NSManaged public func removeFromPostingToPhoto(_ values: NSSet)
+
+}
+
+extension PostingEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/RoomEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/RoomEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  RoomEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(RoomEntity)
+public class RoomEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
@@ -1,0 +1,66 @@
+//
+//  RoomEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension RoomEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<RoomEntity> {
+        return NSFetchRequest<RoomEntity>(entityName: "RoomEntity")
+    }
+
+    @NSManaged public var clientName: String?
+    @NSManaged public var endDate: Date?
+    @NSManaged public var inviteCode: String?
+    @NSManaged public var roomID: Int32
+    @NSManaged public var startDate: Date?
+    @NSManaged public var warrantyTime: Int32
+    @NSManaged public var roomToWorkingStatus: NSSet?
+    @NSManaged public var roomToPosting: NSSet?
+
+}
+
+// MARK: Generated accessors for roomToWorkingStatus
+extension RoomEntity {
+
+    @objc(addRoomToWorkingStatusObject:)
+    @NSManaged public func addToRoomToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(removeRoomToWorkingStatusObject:)
+    @NSManaged public func removeFromRoomToWorkingStatus(_ value: WorkingStatusEntity)
+
+    @objc(addRoomToWorkingStatus:)
+    @NSManaged public func addToRoomToWorkingStatus(_ values: NSSet)
+
+    @objc(removeRoomToWorkingStatus:)
+    @NSManaged public func removeFromRoomToWorkingStatus(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for roomToPosting
+extension RoomEntity {
+
+    @objc(addRoomToPostingObject:)
+    @NSManaged public func addToRoomToPosting(_ value: PostingEntity)
+
+    @objc(removeRoomToPostingObject:)
+    @NSManaged public func removeFromRoomToPosting(_ value: PostingEntity)
+
+    @objc(addRoomToPosting:)
+    @NSManaged public func addToRoomToPosting(_ values: NSSet)
+
+    @objc(removeRoomToPosting:)
+    @NSManaged public func removeFromRoomToPosting(_ values: NSSet)
+
+}
+
+extension RoomEntity : Identifiable {
+
+}

--- a/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/RoomEntity+CoreDataProperties.swift
@@ -18,7 +18,6 @@ extension RoomEntity {
 
     @NSManaged public var clientName: String?
     @NSManaged public var endDate: Date?
-    @NSManaged public var inviteCode: String?
     @NSManaged public var roomID: Int32
     @NSManaged public var startDate: Date?
     @NSManaged public var warrantyTime: Int32

--- a/Samsam/CoreData/WorkingStatusEntity+CoreDataClass.swift
+++ b/Samsam/CoreData/WorkingStatusEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  WorkingStatusEntity+CoreDataClass.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(WorkingStatusEntity)
+public class WorkingStatusEntity: NSManagedObject {
+
+}

--- a/Samsam/CoreData/WorkingStatusEntity+CoreDataProperties.swift
+++ b/Samsam/CoreData/WorkingStatusEntity+CoreDataProperties.swift
@@ -1,0 +1,30 @@
+//
+//  WorkingStatusEntity+CoreDataProperties.swift
+//  Samsam
+//
+//  Created by 김민택 on 2022/10/21.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension WorkingStatusEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WorkingStatusEntity> {
+        return NSFetchRequest<WorkingStatusEntity>(entityName: "WorkingStatusEntity")
+    }
+
+    @NSManaged public var categoryID: Int32
+    @NSManaged public var roomID: Int32
+    @NSManaged public var status: Int32
+    @NSManaged public var statusID: Int32
+    @NSManaged public var workingStatusToCategory: CategoryEntity?
+    @NSManaged public var workingStatusToRoom: RoomEntity?
+
+}
+
+extension WorkingStatusEntity : Identifiable {
+
+}

--- a/Samsam/Global/AppDelegate.swift
+++ b/Samsam/Global/AppDelegate.swift
@@ -25,27 +25,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     // MARK: - Core Data stack
-        lazy var persistentContainer: NSPersistentContainer = {
-            let container = NSPersistentContainer(name: "DataTable")
-            container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-                if let error = error as NSError? {
-                    fatalError("Unresolved error \(error), \(error.userInfo)")
-                }
-            })
-            return container
-        }()
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "DataTable")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
 
-        // MARK: - Core Data Saving support
-        func saveContext () {
-            let context = persistentContainer.viewContext
-            if context.hasChanges {
-                do {
-                    try context.save()
-                } catch {
-                    let nserror = error as NSError
-                    fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-                }
+    // MARK: - Core Data Saving support
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
             }
         }
+    }
 }
 

--- a/Samsam/Global/AppDelegate.swift
+++ b/Samsam/Global/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 김민택 on 2022/10/17.
 //
 
+import CoreData
 import UIKit
 
 @main
@@ -22,7 +23,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
     }
+    
+    // MARK: - Core Data stack
+        lazy var persistentContainer: NSPersistentContainer = {
+            let container = NSPersistentContainer(name: "DataTable")
+            container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+                if let error = error as NSError? {
+                    fatalError("Unresolved error \(error), \(error.userInfo)")
+                }
+            })
+            return container
+        }()
 
-
+        // MARK: - Core Data Saving support
+        func saveContext () {
+            let context = persistentContainer.viewContext
+            if context.hasChanges {
+                do {
+                    try context.save()
+                } catch {
+                    let nserror = error as NSError
+                    fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+                }
+            }
+        }
 }
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 서버를 본격적으로 구축하기 전, 유저 테스트를 위해 임시로 사용할 데이터를 저장 및 관리하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- CoreDataModel 추가
- CoreData Class 및 Properties 추가
- CoreData를 사용하기 위해 AppDelegate에 persistentContainer 추가
- CoreDataManager 추가

## ToDo 📆 (남은 작업)
- [ ] 뷰에 코어데이터 연결

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 서버 구축 전에 임시로 사용하기 위한 코어 데이터가 만들어졌습니다.
- 현재 코어데이터가 전역으로 선언되어 있습니다. 해당 부분은 추후 싱글톤으로 변경되거나, 그 전에 서버 구축으로 삭제될 예정입니다. 이 부분 양해 부탁드립니다.
- 또한, 코어 데이터 기본 생성 코드가 약 400 라인 정도 되는 관계로 현재 PR에 776 라인이 추가 되었습니다. 이 부분도 양해 부탁드립니다.
- 물론, 코어 데이터 매니저로 작성한 코드도 331 라인으로 250 라인을 훨씬 넘어가고 있습니다. 이 부분에 대해서는 앞으로 주의하겠습니다.
- 코어 데이터는 서버 구축 전 데이터를 다루기 위한 아주 중요한 부분입니다. 꼼꼼한 리뷰 부탁드립니다.
- 추가로, 데이터 연동에 있어서 논의가 필요한 부분이 있을 수 있습니다. 논의가 필요할 때에는 빠르게 말씀 부탁드립니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #44.
