### PR TITLE
[Feature] 시공내역 뷰(WorkingHistoryView) 네비게이션 기능 추가, 컨텐츠 타입 추가

### DIFF
--- a/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
+++ b/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
@@ -29,11 +29,21 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         return $0
     }(UILabel())
     
-    private let workType: UIView = {
+    private let workTypeView: UIView = {
+        $0.backgroundColor = .purple
+        $0.layer.cornerRadius = 16
         return $0
     }(UIView())
     
-    private let vStack: UIStackView = {
+    let workType: UILabel = {
+        $0.text = "철거"
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.textAlignment = .center
+        $0.textColor = .white
+        return $0
+    }(UILabel())
+    
+    let vStack: UIStackView = {
         $0.backgroundColor = .white
         $0.axis = .vertical
         $0.layer.masksToBounds = false
@@ -45,6 +55,8 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         return $0
     }(UIStackView())
     
+    // MARK: - Init
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         layout()
@@ -54,9 +66,13 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         fatalError("init(coder:) 가 실행되지 않았습니다.")
     }
     
+    // MARK: - Method
+    
     private func layout() {
         addSubview(vStack)
         vStack.addArrangedSubview(uiImageView)
+        uiImageView.addSubview(workTypeView)
+        workTypeView.addSubview(workType)
         vStack.addArrangedSubview(imageDescription)
         
         vStack.anchor(
@@ -71,6 +87,24 @@ class WorkingHistoryViewCell: UICollectionViewCell {
             left: vStack.leftAnchor,
             bottom: imageDescription.topAnchor,
             right: vStack.rightAnchor
+        )
+        
+        workTypeView.anchor(
+            top: uiImageView.topAnchor,
+            left: uiImageView.leftAnchor,
+            paddingTop: 8,
+            paddingLeft: 8
+        )
+        
+        workType.anchor(
+            top: workTypeView.topAnchor,
+            left: workTypeView.leftAnchor,
+            bottom: workTypeView.bottomAnchor,
+            right: workTypeView.rightAnchor,
+            paddingTop: 8,
+            paddingLeft: 12,
+            paddingBottom: 8,
+            paddingRight: 12
         )
         
         imageDescription.anchor(

--- a/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
+++ b/Samsam/ViewController/WorkingHistoryView/UIComponent/WorkingHistoryViewCell.swift
@@ -43,7 +43,7 @@ class WorkingHistoryViewCell: UICollectionViewCell {
         return $0
     }(UILabel())
     
-    let vStack: UIStackView = {
+    private let vStack: UIStackView = {
         $0.backgroundColor = .white
         $0.axis = .vertical
         $0.layer.masksToBounds = false

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -115,9 +115,8 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewCell.identifier, for: indexPath) as! WorkingHistoryViewCell
         cell.imageDescription.text = "애플, 동아시아 최초 '디벨로퍼 아카데미' 한국서 운영"
-        cell.imageDescription.textAlignment = .center
-        cell.imageDescription.font = UIFont.systemFont(ofSize: 16, weight: .regular)
-        
+        cell.workType.text = "철거"
+
         return cell
     }
     
@@ -126,5 +125,10 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         let cellHeight = width / 4 * 3 + 30
         
         return CGSize(width: Int(width), height: Int(cellHeight))
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let detailViewController = DetailViewController()
+        navigationController?.pushViewController(detailViewController, animated: true)
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 시공내용의 이미지 및 설명 클릭 시 해당 세부내용으로 이동하기 위함
- Navigation 코드 수정 -> didSelectItemAt

## Key Changes 🔥 (주요 구현/변경 사항)
- Navigation
- 컨텐츠(이미지, 설명) 타입(철거) 추가

## ToDo 📆 (남은 작업)
- [ ] 없음.

## ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/98405970/197351636-6d64530d-36a9-4539-b11f-8ae81fb8aace.mp4

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 코드입니다. 가볍게 확인하시면 되겠습니다.
- Rebase 중 문제가 생겨 새 브랜치로 다시 PR을 올렸습니다.
- 혼란 방지를 위해 지난 PR은 Close하겠습니다.

## Close Issues 🔒 (닫을 Issue)
Close #47 .
