### PR TITLE
[Feature] 번호 입력 시 확인버튼 Disable/Enable 상태 변화

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -32,13 +32,12 @@
 		26FEC1E4290466F2006C410B /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FEC1E3290466F2006C410B /* CoreDataManager.swift */; };
 		4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369690B28FE422100DEA89F /* PostingImageViewController.swift */; };
 		4386FB022901353B00314936 /* RoomCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4386FB012901353B00314936 /* RoomCategoryViewController.swift */; };
+		43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43956D2B28FF9F0100DD996F /* PostingWritingView.swift */; };
 		43BD591A29028BD70063EB4F /* RoomCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BD591929028BD70063EB4F /* RoomCodeViewController.swift */; };
 		43C2110F28FCFAB500E8F6DD /* PostingCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */; };
 		43C2111128FCFB3800E8F6DD /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2111028FCFB3800E8F6DD /* CategoryCell.swift */; };
 		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		98366F8D29019A5300E81E27 /* RoomCreationViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */; };
-		43956D2C28FF9F0100DD996F /* PostingWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43956D2B28FF9F0100DD996F /* PostingWritingView.swift */; };
-		980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980D900D28FE671B003CC2DA /* DetailViewController.swift */; };
 		98C0D06028FCE8EB00E0E439 /* AutoLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */; };
 		98C0D06428FCE99300E0E439 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06328FCE99300E0E439 /* JSON.swift */; };
 		98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06628FCE9DC00E0E439 /* Model.swift */; };
@@ -46,6 +45,7 @@
 		98C0D06C28FCF46500E0E439 /* WorkingHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D06B28FCF46500E0E439 /* WorkingHistoryViewController.swift */; };
 		98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D07128FD02E400E0E439 /* WorkingHistoryViewCell.swift */; };
 		98C2448B28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C2448A28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift */; };
+		98E1700D2906EFEB00F71D41 /* hideKeyboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -77,13 +77,12 @@
 		26FEC1E3290466F2006C410B /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		4369690B28FE422100DEA89F /* PostingImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingImageViewController.swift; sourceTree = "<group>"; };
 		4386FB012901353B00314936 /* RoomCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCategoryViewController.swift; sourceTree = "<group>"; };
+		43956D2B28FF9F0100DD996F /* PostingWritingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingWritingView.swift; sourceTree = "<group>"; };
 		43BD591929028BD70063EB4F /* RoomCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCodeViewController.swift; sourceTree = "<group>"; };
 		43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingCategoryViewController.swift; sourceTree = "<group>"; };
 		43C2111028FCFB3800E8F6DD /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		98366F8C29019A5300E81E27 /* RoomCreationViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCreationViewContoller.swift; sourceTree = "<group>"; };
-		43956D2B28FF9F0100DD996F /* PostingWritingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingWritingView.swift; sourceTree = "<group>"; };
-		980D900D28FE671B003CC2DA /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayout+.swift"; sourceTree = "<group>"; };
 		98C0D06328FCE99300E0E439 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		98C0D06628FCE9DC00E0E439 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
@@ -91,6 +90,7 @@
 		98C0D06B28FCF46500E0E439 /* WorkingHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewController.swift; sourceTree = "<group>"; };
 		98C0D07128FD02E400E0E439 /* WorkingHistoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewCell.swift; sourceTree = "<group>"; };
 		98C2448A28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewHeader.swift; sourceTree = "<group>"; };
+		98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "hideKeyboard+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,6 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */,
+				98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -331,6 +332,7 @@
 				26E3749C28FE8E6F00997DA7 /* LoginViewController.swift in Sources */,
 				980D900E28FE671B003CC2DA /* DetailViewController.swift in Sources */,
 				26E3748628FCDC0000997DA7 /* ViewController.swift in Sources */,
+				98E1700D2906EFEB00F71D41 /* hideKeyboard+.swift in Sources */,
 				98C0D06C28FCF46500E0E439 /* WorkingHistoryViewController.swift in Sources */,
 				26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */,
 				98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */,

--- a/Samsam/Global/Extension/hideKeyboard+.swift
+++ b/Samsam/Global/Extension/hideKeyboard+.swift
@@ -1,0 +1,22 @@
+//
+//  hideKeyboard+.swift
+//  Samsam
+//
+//  Created by 지준용 on 2022/10/25.
+//
+
+import UIKit
+
+
+extension UIViewController {
+
+    func hidekeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc func endEditingView() {
+        view.endEditing(true)
+    }
+}

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -126,8 +126,9 @@ class PhoneNumViewController: UIViewController {
         
         submitButton.anchor(
             left: uiView.leftAnchor,
-            bottom: uiView.bottomAnchor,
-            right: uiView.rightAnchor
+            bottom: view.keyboardLayoutGuide.topAnchor,
+            right: uiView.rightAnchor,
+            paddingBottom: 20
         )
     }
     

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -68,6 +68,7 @@ class PhoneNumViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
+        submitButton.addTarget(self, action: #selector(tapSubmitButton), for: .touchUpInside)
     }
     
     private func layout() {
@@ -128,5 +129,10 @@ class PhoneNumViewController: UIViewController {
             bottom: uiView.bottomAnchor,
             right: uiView.rightAnchor
         )
+    }
+    
+    @objc private func tapSubmitButton() {
+        let roomListViewController = RoomListViewController()
+        navigationController?.pushViewController(roomListViewController, animated: true)
     }
 }

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -32,7 +32,7 @@ class PhoneNumViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private var numberInput: UITextField = {
+    private let numberInput: UITextField = {
         $0.placeholder = "1234-5678"
         $0.font = UIFont.systemFont(ofSize: 16)
         $0.keyboardType = .decimalPad
@@ -45,12 +45,11 @@ class PhoneNumViewController: UIViewController {
         return $0
     }(UIView())
     
-    private var submitButton: UIButton = {
+    private let submitButton: UIButton = {
         $0.setTitle("확인", for: .normal)
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         $0.setHeight(height: 50)
         $0.layer.cornerRadius = 16
-        $0.setTitle("확인", for: .normal)
         $0.isEnabled = false
         $0.backgroundColor = .gray
         return $0

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class PhoneNumViewController: UIViewController {
-    
+
     // MARK: - View
     
     private let uiView: UIView = {
@@ -32,9 +32,10 @@ class PhoneNumViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private lazy var numberInput: UITextField = {
+    var numberInput: UITextField = {
         $0.placeholder = "1234-5678"
         $0.font = UIFont.systemFont(ofSize: 16)
+        $0.keyboardType = .decimalPad
         return $0
     }(UITextField())
     
@@ -44,11 +45,11 @@ class PhoneNumViewController: UIViewController {
         return $0
     }(UIView())
     
-    private let submitButton: UIButton = {
+    private lazy var submitButton: UIButton = {
         $0.setTitle("확인", for: .normal)
         $0.setTitleColor(.white, for: .normal)
-        $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         $0.backgroundColor = .blue
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         $0.setHeight(height: 50)
         $0.layer.cornerRadius = 16
         return $0
@@ -58,7 +59,7 @@ class PhoneNumViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        hidekeyboardWhenTappedAround()
         attribute()
         layout()
     }

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -32,7 +32,7 @@ class PhoneNumViewController: UIViewController {
         return $0
     }(UILabel())
     
-    var numberInput: UITextField = {
+    private var numberInput: UITextField = {
         $0.placeholder = "1234-5678"
         $0.font = UIFont.systemFont(ofSize: 16)
         $0.keyboardType = .decimalPad
@@ -45,13 +45,14 @@ class PhoneNumViewController: UIViewController {
         return $0
     }(UIView())
     
-    private lazy var submitButton: UIButton = {
+    private var submitButton: UIButton = {
         $0.setTitle("확인", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .blue
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
         $0.setHeight(height: 50)
         $0.layer.cornerRadius = 16
+        $0.setTitle("확인", for: .normal)
+        $0.isEnabled = false
+        $0.backgroundColor = .gray
         return $0
     }(UIButton())
     
@@ -68,7 +69,7 @@ class PhoneNumViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
-        submitButton.addTarget(self, action: #selector(tapSubmitButton), for: .touchUpInside)
+        numberInput.addTarget(self, action: #selector(buttonAttributeChanged), for: .editingChanged)
     }
     
     private func layout() {
@@ -130,6 +131,17 @@ class PhoneNumViewController: UIViewController {
             right: uiView.rightAnchor,
             paddingBottom: 20
         )
+    }
+
+    @objc private func buttonAttributeChanged() {
+        if (numberInput.text!.count) == 8 {
+            submitButton.backgroundColor = .blue
+            submitButton.isEnabled = true
+            submitButton.addTarget(self, action: #selector(tapSubmitButton), for: .touchUpInside)
+        } else {
+            submitButton.backgroundColor = .gray
+            submitButton.isEnabled = false
+        }
     }
     
     @objc private func tapSubmitButton() {

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -129,16 +129,6 @@ class PostingWritingView: UIViewController {
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
     
-    func hidekeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))
-        tap.cancelsTouchesInView = false
-        view.addGestureRecognizer(tap)
-    }
-    
-    @objc func endEditingView() {
-        view.endEditing(true)
-    }
-    
     private func setupNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -80,7 +80,7 @@ class WorkingHistoryViewController: UIViewController {
     // TODO: - postingCategoryView를 FullScreen모달로 띄우는 기능. 추후 수정
 
     @objc func tapWritingButton() {
-        let postingCategoryView = ViewController()
+        let postingCategoryView = PostingCategoryViewController()
         postingCategoryView.modalPresentationStyle = .fullScreen
         present(postingCategoryView, animated:  true, completion: nil)
     }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- HideKeyBoard 여러 곳에서 반영가능해야하기 때문.
- Keyboard가 올라오면 뷰 내 컴포넌트가 같이 올라와야 하기 때문.
- UX를 위해 핸드폰번호 입력 시 버튼 활성화/비활성화 처리해야하기 때문.

## Key Changes 🔥 (주요 구현/변경 사항)
- HideKeyboard Extension 처리
- KeyboardLayoutGuide
- TextField입력 시 UIButton EditingChanged
- 방 목록 뷰로 Navigation

## ToDo 📆 (남은 작업)
- [ ] 연락처 DB저장
- [ ] 정규표현식을 활용한 전화번호 형식 맞추기
- [ ] 양식 불일치 시 Alert or Fucusing or Hight

## ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/98405970/197750302-ddc582ab-9c46-4bce-be6b-ef7ec12eb621.mp4

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단하고 짧은 코드입니다. 가볍게 확인하시면 되겠습니다.
- UIControl에 대한 이해가 깊어졌네요. 관련 자료 공유합니다.

## Reference 🔗
- UIControl관련 자료: https://babamba-playground.tistory.com/22

## Close Issues 🔒 (닫을 Issue)
Close #54.
