### PR TITLE
[Feature] 시공상황 작성 뷰, 풀스크린모달 및 네비게이션컨트롤 구현

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		98C0D07228FD02E400E0E439 /* WorkingHistoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D07128FD02E400E0E439 /* WorkingHistoryViewCell.swift */; };
 		98C2448B28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C2448A28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift */; };
 		98E1700D2906EFEB00F71D41 /* hideKeyboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */; };
+		98E1700F29080C9100F71D41 /* ImageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E1700E29080C9100F71D41 /* ImageDetailViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -91,6 +92,7 @@
 		98C0D07128FD02E400E0E439 /* WorkingHistoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewCell.swift; sourceTree = "<group>"; };
 		98C2448A28FD3EDA0006A01B /* WorkingHistoryViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewHeader.swift; sourceTree = "<group>"; };
 		98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "hideKeyboard+.swift"; sourceTree = "<group>"; };
+		98E1700E29080C9100F71D41 /* ImageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +205,7 @@
 				26E3749B28FE8E6F00997DA7 /* LoginViewController.swift */,
 				26E3749E28FE9DA300997DA7 /* PhoneNumViewController.swift */,
 				980D900C28FE6705003CC2DA /* DetailView */,
+				98E1700E29080C9100F71D41 /* ImageDetailViewController.swift */,
 				43C2111028FCFB3800E8F6DD /* CategoryCell.swift */,
 				43C2110E28FCFAB500E8F6DD /* PostingCategoryViewController.swift */,
 				4369690B28FE422100DEA89F /* PostingImageViewController.swift */,
@@ -363,6 +366,7 @@
 				26FEC1D92902E6F2006C410B /* CategoryEntity+CoreDataClass.swift in Sources */,
 				4369690C28FE422100DEA89F /* PostingImageViewController.swift in Sources */,
 				26FEC1DF2902E6F2006C410B /* PhotoEntity+CoreDataClass.swift in Sources */,
+				98E1700F29080C9100F71D41 /* ImageDetailViewController.swift in Sources */,
 				26FEC1E22902E6F2006C410B /* RoomEntity+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -31,7 +31,6 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         $0.showsHorizontalScrollIndicator = false
         $0.isPagingEnabled = true
         $0.layer.cornerRadius = 16
-        
         return $0
     }(UIScrollView())
     

--- a/Samsam/ViewController/ImageDetailViewController.swift
+++ b/Samsam/ViewController/ImageDetailViewController.swift
@@ -1,0 +1,52 @@
+//
+//  ImageDetailViewController.swift
+//  Samsam
+//
+//  Created by 지준용 on 2022/10/25.
+//
+
+import UIKit
+
+class ImageDetailViewController: UIViewController {
+    
+    private var isTapped = false
+    
+    // MARK: - View
+    
+    private let uiView: UIView = {
+        return $0
+    }(UIView())
+    
+    private let detailImage: UIImageView = {
+        $0.image = UIImage(named: "TestImage")
+        $0.contentMode = .scaleAspectFit
+        return $0
+    }(UIImageView())
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        layout()
+        attribute()
+    }
+    
+    // MARK: - Method
+    
+    private func layout() {
+        view.addSubview(detailImage)
+
+        detailImage.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor
+        )
+    }
+    
+    private func attribute() {
+        view.backgroundColor = .white
+        navigationItem.title = "화장실"
+    }
+}
+

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -77,12 +77,11 @@ class WorkingHistoryViewController: UIViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
     }
     
-    // TODO: - postingCategoryView를 FullScreen모달로 띄우는 기능. 추후 수정
-
     @objc func tapWritingButton() {
-        let postingCategoryView = PostingCategoryViewController()
-        postingCategoryView.modalPresentationStyle = .fullScreen
-        present(postingCategoryView, animated:  true, completion: nil)
+        let createVC = PostingCategoryViewController()
+        let navigationController = UINavigationController(rootViewController: createVC)
+        navigationController.modalPresentationStyle = .overFullScreen
+        present(navigationController, animated:  true, completion: nil)
     }
 }
 

--- a/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -80,7 +80,7 @@ class WorkingHistoryViewController: UIViewController {
     @objc func tapWritingButton() {
         let createVC = PostingCategoryViewController()
         let navigationController = UINavigationController(rootViewController: createVC)
-        navigationController.modalPresentationStyle = .overFullScreen
+        navigationController.modalPresentationStyle = .fullScreen
         present(navigationController, animated:  true, completion: nil)
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 시공상황 작성 뷰, 풀스크린모달 및 네비게이션컨트롤 구현

## Key Changes 🔥 (주요 구현/변경 사항)
- 시공상황 작성 뷰, 풀스크린모달 및 네비게이션컨트롤 구현

## ToDo 📆 (남은 작업)

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 14 - 2022-10-26 at 11 34 42](https://user-images.githubusercontent.com/92836045/197920947-48597533-310b-4de5-b1f5-daecdce7fec4.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- fullscreen이 아닌, overfullscreen으로 했습니다. (overfullscreen을 해야 view 계충에 기존 view가 존재하기 때문입니다!)
- 중간에 작성 취소 버튼이 들어가야할지 논의 필요 ( 첫 번째 페이지에는 있어야 할 것 같습니다 )

## Reference 🔗
- fullscreen vs overfullscreen
https://onelife2live.tistory.com/34
https://magi82.github.io/ios-modal-presentation-style-01/

## Close Issues 🔒 (닫을 Issue)
Close #64 
