### PR TITLE
[Feature] 사진 핀치, 드래그를 이용한 제스처 활용

### DIFF
--- a/Samsam/ViewController/ImageDetailViewController.swift
+++ b/Samsam/ViewController/ImageDetailViewController.swift
@@ -47,6 +47,22 @@ class ImageDetailViewController: UIViewController {
     private func attribute() {
         view.backgroundColor = .white
         navigationItem.title = "화장실"
+
+        detailImage.isUserInteractionEnabled = true
+
+        let didDoubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(didDoubleTapGesture))
+        didDoubleTapGesture.numberOfTapsRequired = 2
+        detailImage.addGestureRecognizer(didDoubleTapGesture)
+    }
+    
+    @objc private func didDoubleTapGesture() {
+        isTapped.toggle()
+
+        if isTapped {
+            detailImage.contentMode = .scaleAspectFill
+        } else {
+            detailImage.contentMode = .scaleAspectFit
+        }
+        detailImage.center = view.center
     }
 }
-

--- a/Samsam/ViewController/ImageDetailViewController.swift
+++ b/Samsam/ViewController/ImageDetailViewController.swift
@@ -53,10 +53,6 @@ class ImageDetailViewController: UIViewController {
         let didPinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(didPinchGesture))
         detailImage.addGestureRecognizer(didPinchGesture)
 
-        let didDoubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(didDoubleTapGesture))
-        didDoubleTapGesture.numberOfTapsRequired = 2
-        detailImage.addGestureRecognizer(didDoubleTapGesture)
-
         let didPanGesture = UIPanGestureRecognizer(target: self, action: #selector(didPanGesture))
         detailImage.addGestureRecognizer(didPanGesture)
     }
@@ -64,17 +60,6 @@ class ImageDetailViewController: UIViewController {
     @objc private func didPinchGesture(_ sender: UIPinchGestureRecognizer) {
         detailImage.transform = detailImage.transform.scaledBy(x: sender.scale, y: sender.scale)
         sender.scale = 1.0
-        detailImage.center = view.center
-    }
-    
-    @objc private func didDoubleTapGesture() {
-        isTapped.toggle()
-
-        if isTapped {
-            detailImage.contentMode = .scaleAspectFill
-        } else {
-            detailImage.contentMode = .scaleAspectFit
-        }
         detailImage.center = view.center
     }
     

--- a/Samsam/ViewController/ImageDetailViewController.swift
+++ b/Samsam/ViewController/ImageDetailViewController.swift
@@ -50,9 +50,18 @@ class ImageDetailViewController: UIViewController {
 
         detailImage.isUserInteractionEnabled = true
 
+        let didPinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(didPinchGesture))
+        detailImage.addGestureRecognizer(didPinchGesture)
+
         let didDoubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(didDoubleTapGesture))
         didDoubleTapGesture.numberOfTapsRequired = 2
         detailImage.addGestureRecognizer(didDoubleTapGesture)
+    }
+    
+    @objc private func didPinchGesture(_ sender: UIPinchGestureRecognizer) {
+        detailImage.transform = detailImage.transform.scaledBy(x: sender.scale, y: sender.scale)
+        sender.scale = 1.0
+        detailImage.center = view.center
     }
     
     @objc private func didDoubleTapGesture() {

--- a/Samsam/ViewController/ImageDetailViewController.swift
+++ b/Samsam/ViewController/ImageDetailViewController.swift
@@ -56,6 +56,9 @@ class ImageDetailViewController: UIViewController {
         let didDoubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(didDoubleTapGesture))
         didDoubleTapGesture.numberOfTapsRequired = 2
         detailImage.addGestureRecognizer(didDoubleTapGesture)
+
+        let didPanGesture = UIPanGestureRecognizer(target: self, action: #selector(didPanGesture))
+        detailImage.addGestureRecognizer(didPanGesture)
     }
     
     @objc private func didPinchGesture(_ sender: UIPinchGestureRecognizer) {
@@ -73,5 +76,14 @@ class ImageDetailViewController: UIViewController {
             detailImage.contentMode = .scaleAspectFit
         }
         detailImage.center = view.center
+    }
+    
+    @objc private func didPanGesture(_ sender: UIPanGestureRecognizer) {
+        let translation = sender.translation(in: view)
+        if let view = sender.view {
+            view.center = CGPoint(x: view.center.x + translation.x,
+                                  y: view.center.y + translation.y)
+        }
+        sender.setTranslation(CGPoint.zero, in: view)
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 사진을 확대해서 보기 위함
 
## Key Changes 🔥 (주요 구현/변경 사항)
- 두 손가락(핀치)를 활용한 사진 확대 / 축소
- 고정된 사진 위치를 이동하며 보기 위한 PanGesture

## ToDo 📆 (남은 작업)
- [ ] DetailView의 scrollView 이미지 클릭하여 네비게이션 이동

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-10-26 at 19 48 59](https://user-images.githubusercontent.com/98405970/198007520-2d088412-d05b-46a7-a2f8-0502a39b4c73.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 완성이라고 할 수 있을까요?
- 더블탭 제스처는 UX고려하여 삭제했습니다. 추후 필요하면 다시 반영하겠습니다.

## Reference 🔗
- PinchGestrue
  - https://moonibot.tistory.com/58
  - https://zeddios.tistory.com/343
- PanGesture
  - https://velog.io/@palinyee12/Pan-Gesture-사용-2
![image](https://user-images.githubusercontent.com/98405970/198008263-80afd03c-5d8e-4846-ba36-d41d74d76098.png)


## Close Issues 🔒 (닫을 Issue)
Close #62.
