### PR TITLE
[Feature] 시공작성 화면 이미지 업로드 뷰 기능 수정 및 추가

### DIFF
--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -177,15 +177,88 @@ class PostingImageViewController: UIViewController {
         })
     }
     
+    // 이미지 업로드 전 카메라 권한 체크 후, 체크가 되면, 이미지 업로드합니다.
+    func checkPermissionandGo(indexPath: Int){
+           switch PHPhotoLibrary.authorizationStatus() {
+           case .denied:
+               didMoveToSetting()
+           case .notDetermined:
+               PHPhotoLibrary.requestAuthorization({ (state) in
+                   if state == .authorized {
+                       DispatchQueue.main.async {
+                           if self.plusBool == true && indexPath == 0 {
+                               self.uploadPhoto(indexPath: indexPath)
+                           } else {
+                               self.makeActionSheet(indexPath: indexPath)
+                           }
+                       }
+                   }
+               })
+           case .authorized:
+               if plusBool == true && indexPath == 0 {
+                   uploadPhoto(indexPath: indexPath)
+               } else {
+                   makeActionSheet(indexPath: indexPath)
+               }
+               // 위에 if문은 이미지 추가 버튼 클릭일 때, 밑에 else는 기존 이미지 클릭일 떄 입니다.
+               //if문에 조건을 설명하자면, plusBool은 이미지 추가 버튼이 있을 때, 그리고 클릭한 이미지 index가 0일 때만 돌아갑니다.
+               //이미지가 4장이 이미 업로드된 상황이라면, plusBool이 fasle이기에 else로 갑니다.
+           default:
+               break
+           }
+       }
+
+    
     // 사진이 불러와지지 않을 때, 알람을 주기 위한 함수
-    private func makeErrorAlert(title: String, message: String? = nil) {
+    private func makeAlert(title: String,
+                           message: String? = nil,
+                           okAction: ((UIAlertAction) -> Void)? = nil,
+                           completion : (() -> Void)? = nil) {
         let alertViewController = UIAlertController(title: title,
                                                     message: message,
                                                     preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "확인", style: .default)
+        let okAction = UIAlertAction(title: "확인", style: .default, handler: okAction)
         alertViewController.addAction(okAction)
-        self.present(alertViewController, animated: true, completion: nil)
+        
+        self.present(alertViewController, animated: true, completion: completion)
     }
+    
+    
+    func makeRequestAlert(title: String,
+                          message: String,
+                          okTitle: String = "확인",
+                          cancelTitle: String = "취소",
+                          okAction: ((UIAlertAction) -> Void)?,
+                          cancelAction: ((UIAlertAction) -> Void)? = nil,
+                          completion : (() -> Void)? = nil) {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        
+        let alertViewController = UIAlertController(title: title, message: message,
+                                                    preferredStyle: .alert)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .default, handler: cancelAction)
+        alertViewController.addAction(cancelAction)
+        
+        let okAction = UIAlertAction(title: okTitle, style: .destructive, handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+    
+    private func didMoveToSetting() {
+        let settingAction: ((UIAlertAction) -> ()) = { _ in
+            guard let settingURL = URL(string: UIApplication.openSettingsURLString) else { return }
+            UIApplication.shared.open(settingURL)
+        }
+        if let appName = Bundle.main.infoDictionary!["CFBundleName"] as? String {
+            makeRequestAlert(title: "설정",
+                             message: "\(appName)이 카메라에 접근이 허용되어 있지 않습니다. 설정화면으로 가시겠습니까?",
+                             okAction: settingAction,
+                             completion: nil)
+        }
+    }
+
     
     // 기존 사진을 클릭했을 때, 사진 변경 or 사진 삭제 알림 창을 띄우는 액션 시트
     private func makeActionSheet(indexPath: Int) {
@@ -230,7 +303,8 @@ class PostingImageViewController: UIViewController {
         self.present(picker, animated: true, completion: nil)
     }
     
-    // 기존 이미지 삭제 함수, changeNUM은 어떤 이미지를 삭제하는 지 알기 위해, plusBool은 4개에서 삭제하면 3개가 되고, 그럴 땐 다시 이미지 추가 버튼이 생겨야 하기에 if문을 돌립니다.
+    // 기존 이미지 삭제 함수, changeNUM은 어떤 이미지를 삭제하는 지 알기 위해,
+    //plusBool은 4개에서 삭제하면 3개가 되고, 그럴 땐 다시 이미지 추가 버튼이 생겨야 하기에 if문을 돌립니다.
     @objc func deletePhoto(indexPath: Int) {
         photoImages.remove(at: indexPath)
         if numberOfItem == 4 {
@@ -249,7 +323,8 @@ extension PostingImageViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true, completion: nil)
         
-        // 밑에 plusIndex는 이미지를 업로드 했을 때, 최근에 누른 것이 위쪽에 보이도록 하기 위해서(이미지 추가 버튼 뒤쪽으로 배열에 넣어야 합니다), 그때 사용됩니다. 그러면 굳이 이렇게 변수로 뺀 이유는? 그건 바로 업로드 된 기존 이미지가 4개일 때, 하나를 삭제하면, 이미지 추가 버튼이 다시 나와야 합니다. 그때는 배열 0에 insert를 해야하기 위해서, 그때는 plusIndex가 0이 됩니다.
+        // 밑에 plusIndex는 이미지를 업로드 했을 때, 최근에 누른 것이 위쪽에 보이도록 하기 위해서(이미지 추가 버튼 뒤쪽으로 배열에 넣어야 합니다), 그때 사용됩니다.
+        //그러면 굳이 이렇게 변수로 뺀 이유는? 그건 바로 업로드 된 기존 이미지가 4개일 때, 하나를 삭제하면, 이미지 추가 버튼이 다시 나와야 합니다. 그때는 배열 0에 insert를 해야하기 위해서, 그때는 plusIndex가 0이 됩니다.
         var plusIndex = 1
         if plusBool == true && changeNUM == 0 { // 이것은 이미지 업로드 되었을 때 돌리는 if문 입니다.
             if results.count + photoImages.count == 5 { // 이것은 이미지 업로드 4장이 되었을 떄, 이미지 추가 버튼을 삭제하기 위함입니다.
@@ -269,7 +344,7 @@ extension PostingImageViewController: PHPickerViewControllerDelegate {
                         }
                         if let error = error {
                             DispatchQueue.main.async {
-                                self?.makeErrorAlert(title: "",message: "사진을 불러올 수 없습니다")
+                                self?.makeAlert(title: "",message: "사진을 불러올 수 없습니다")
                             }
                         }
                     }
@@ -287,7 +362,7 @@ extension PostingImageViewController: PHPickerViewControllerDelegate {
                         }
                         if let error = error {
                             DispatchQueue.main.async {
-                                self?.makeErrorAlert(title: "",message: "사진을 불러올 수 없습니다")
+                                self?.makeAlert(title: "",message: "사진을 불러올 수 없습니다")
                             }
                         }
                     }
@@ -314,13 +389,7 @@ extension PostingImageViewController:  UICollectionViewDelegate, UICollectionVie
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
-        // 위에 if문은 이미지 추가 버튼 클릭일 때, 밑에 else는 기존 이미지 클릭일 떄 입니다. if문에 조건을 설명하자면, plusBool은 이미지 추가 버튼이 있을 때, 그리고 클릭한 이미지 index가 0일 때만 돌아갑니다. 이미지가 4장이 이미 업로드된 상황이라면, plusBool이 fasle이기에 else로 갑니다.
-        if plusBool == true && indexPath.row == 0 {
-            uploadPhoto(indexPath: indexPath.row)
-        } else {
-            makeActionSheet(indexPath: indexPath.row)
-        }
+        checkPermissionandGo(indexPath: indexPath.row)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -23,9 +23,9 @@ class PostingImageViewController: UIViewController {
     var exampleNUM = 0
     
     private var photoImages: [cellItem] = [cellItem(image: UIImage(named: "CameraBTN"))]
-    private var copyPhotoImages: [cellItem]?
-    private var changeNUM: Int?
-    private var plusBool: Bool = true
+    private var copyPhotoImages: [cellItem]? // 다음 뷰에 이미지들을 넘길 때 사용될 배열
+    private var changeNUM: Int? // 이미지 변경 시, 사용될 index 번호
+    private var plusBool: Bool = true // plus 버튼이 나타날 지, 없어질 지에 관하여 사용될 Bool
     
     // MARK: - View
     
@@ -204,6 +204,18 @@ class PostingImageViewController: UIViewController {
         alert.addAction(cancelAction)
         
         present(alert, animated: true, completion: nil)
+    }
+    
+    // 새로운 사진 업로드 함수
+    @objc func uploadPhoto(indexPath: Int) {
+        changeNUM = indexPath
+        var configure = PHPickerConfiguration()
+        configure.selectionLimit = 4 - numberOfItem
+        configure.selection = .ordered
+        configure.filter = .images
+        let picker = PHPickerViewController(configuration: configure)
+        picker.delegate = self
+        self.present(picker, animated: true, completion: nil)
     }
     
     // 기존 이미지 변경 함수, 여기서 changeNUM은 어떤 이미지를 바꾸는 지 알아야 하기에 필요합니다!

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -178,7 +178,7 @@ class PostingImageViewController: UIViewController {
     }
     
     // 사진이 불러와지지 않을 때, 알람을 주기 위한 함수
-    private func makeErrorAlert(tittle: String, message: String? = nil) {
+    private func makeErrorAlert(title: String, message: String? = nil) {
         let alertViewController = UIAlertController(title: title,
                                                     message: message,
                                                     preferredStyle: .alert)

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -314,7 +314,13 @@ extension PostingImageViewController:  UICollectionViewDelegate, UICollectionVie
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        setPhoto(indexPath: indexPath.row)
+        
+        // 위에 if문은 이미지 추가 버튼 클릭일 때, 밑에 else는 기존 이미지 클릭일 떄 입니다. if문에 조건을 설명하자면, plusBool은 이미지 추가 버튼이 있을 때, 그리고 클릭한 이미지 index가 0일 때만 돌아갑니다. 이미지가 4장이 이미 업로드된 상황이라면, plusBool이 fasle이기에 else로 갑니다.
+        if plusBool == true && indexPath.row == 0 {
+            uploadPhoto(indexPath: indexPath.row)
+        } else {
+            makeActionSheet(indexPath: indexPath.row)
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -158,13 +158,25 @@ class PostingImageViewController: UIViewController {
         label.alpha = 0
         self.view.addSubview(label)
         
-        if plusBool == true {
-            configure.selectionLimit = 4 - numberOfItem
-        } else {
-            configure.selectionLimit = 1
-            changeNUM = indexPath
-        }
-
+        label.anchor(
+            bottom: nextBTN.topAnchor,
+            paddingBottom: 30,
+            width: 240,
+            height: 30
+        )
+        label.centerX(inView: self.view)
+        
+        UIView.animate(withDuration: 0.5, animations: {
+            label.alpha = 0.8
+        }, completion: { isCompleted in
+            UIView.animate(withDuration: 2.0, animations: {
+                label.alpha = 0
+            }, completion: { isCompleted in
+                label.removeFromSuperview()
+            })
+        })
+    }
+    
         configure.selection = .ordered
         configure.filter = .images
         let picker = PHPickerViewController(configuration: configure)

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -269,7 +269,7 @@ extension PostingImageViewController: PHPickerViewControllerDelegate {
                         }
                         if let error = error {
                             DispatchQueue.main.async {
-                                self?.makeErrorAlert(tittle: "",message: "사진을 불러올 수 없습니다")
+                                self?.makeErrorAlert(title: "",message: "사진을 불러올 수 없습니다")
                             }
                         }
                     }
@@ -287,7 +287,7 @@ extension PostingImageViewController: PHPickerViewControllerDelegate {
                         }
                         if let error = error {
                             DispatchQueue.main.async {
-                                self?.makeErrorAlert(tittle: "",message: "사진을 불러올 수 없습니다")
+                                self?.makeErrorAlert(title: "",message: "사진을 불러올 수 없습니다")
                             }
                         }
                     }

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -132,19 +132,31 @@ class PostingImageViewController: UIViewController {
         postingWritingView.roomID = roomID
         postingWritingView.categoryID = categoryID
         
-        if numberOfItem > 3 {
+        if numberOfItem == 0 {
+            showToast()
+        } else if numberOfItem > 3 {
             postingWritingView.photoImages = photoImages
+            navigationController?.pushViewController(postingWritingView, animated: true)
         } else {
             copyPhotoImages = photoImages
             copyPhotoImages?.remove(at: 0)
             postingWritingView.photoImages = copyPhotoImages
+            navigationController?.pushViewController(postingWritingView, animated: true)
         }
-        navigationController?.pushViewController(postingWritingView, animated: true)
     }
-
-    @objc func setPhoto(indexPath: Int) {
-        var configure = PHPickerConfiguration()
-       
+    
+    // 이미지를 하나도 선택하지 않고 다음 뷰를 넘어갈 때, 이를 방지하기 위한 함수
+    private func showToast() {
+        let label = UILabel()
+        label.backgroundColor = .lightGray
+        label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        label.textAlignment = .center
+        label.text = "사진을 하나 이상 선택해주세요!"
+        label.layer.cornerRadius = 8
+        label.clipsToBounds = true
+        label.alpha = 0
+        self.view.addSubview(label)
         
         if plusBool == true {
             configure.selectionLimit = 4 - numberOfItem

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -186,11 +186,47 @@ class PostingImageViewController: UIViewController {
         alertViewController.addAction(okAction)
         self.present(alertViewController, animated: true, completion: nil)
     }
+    
+    // 기존 사진을 클릭했을 때, 사진 변경 or 사진 삭제 알림 창을 띄우는 액션 시트
+    private func makeActionSheet(indexPath: Int) {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        let okAction = UIAlertAction(title: "사진 변경하기", style: .default, handler: { action in
+            self.changePhoto(indexPath: indexPath)
+        })
+        let removeAction = UIAlertAction(title: "사진 삭제하기", style: .destructive, handler: { action in
+            self.deletePhoto(indexPath: indexPath)
+        })
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        
+        alert.addAction(okAction)
+        alert.addAction(removeAction)
+        alert.addAction(cancelAction)
+        
+        present(alert, animated: true, completion: nil)
+    }
+    
+    // 기존 이미지 변경 함수, 여기서 changeNUM은 어떤 이미지를 바꾸는 지 알아야 하기에 필요합니다!
+    @objc func changePhoto(indexPath: Int) {
+        changeNUM = indexPath
+        var configure = PHPickerConfiguration()
+        configure.selectionLimit = 1
         configure.selection = .ordered
         configure.filter = .images
         let picker = PHPickerViewController(configuration: configure)
         picker.delegate = self
         self.present(picker, animated: true, completion: nil)
+    }
+    
+    // 기존 이미지 삭제 함수, changeNUM은 어떤 이미지를 삭제하는 지 알기 위해, plusBool은 4개에서 삭제하면 3개가 되고, 그럴 땐 다시 이미지 추가 버튼이 생겨야 하기에 if문을 돌립니다.
+    @objc func deletePhoto(indexPath: Int) {
+        photoImages.remove(at: indexPath)
+        if numberOfItem == 4 {
+            plusBool = true
+            photoImages.insert(cellItem(image: UIImage(named: "CameraBTN")), at: 0)
+        }
+        numberOfItem = numberOfItem - 1
+        imageCellView.reloadData()
     }
 }
 

--- a/Samsam/ViewController/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingImageViewController.swift
@@ -177,6 +177,15 @@ class PostingImageViewController: UIViewController {
         })
     }
     
+    // 사진이 불러와지지 않을 때, 알람을 주기 위한 함수
+    private func makeErrorAlert(tittle: String, message: String? = nil) {
+        let alertViewController = UIAlertController(title: title,
+                                                    message: message,
+                                                    preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default)
+        alertViewController.addAction(okAction)
+        self.present(alertViewController, animated: true, completion: nil)
+    }
         configure.selection = .ordered
         configure.filter = .images
         let picker = PHPickerViewController(configuration: configure)

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -67,7 +67,6 @@ class PostingWritingView: UIViewController {
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
-        print(photoImages?.count)
         super.viewDidLoad()
         attribute()
         layout()

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -13,7 +13,7 @@ class PostingWritingView: UIViewController {
     
     var roomID: Int?
     var categoryID: Int?
-//    var imgItems: [PreviewItem]?
+    var photoImages: [cellItem]?
     private let textViewPlaceHolder = "텍스트를 입력하세요"
 
     // MARK: - View
@@ -67,6 +67,7 @@ class PostingWritingView: UIViewController {
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
+        print(photoImages?.count)
         super.viewDidLoad()
         attribute()
         layout()

--- a/Samsam/ViewController/PostingWritingView.swift
+++ b/Samsam/ViewController/PostingWritingView.swift
@@ -13,7 +13,7 @@ class PostingWritingView: UIViewController {
     
     var roomID: Int?
     var categoryID: Int?
-    var imgItems: [PreviewItem]?
+//    var imgItems: [PreviewItem]?
     private let textViewPlaceHolder = "텍스트를 입력하세요"
 
     // MARK: - View
@@ -135,9 +135,9 @@ class PostingWritingView: UIViewController {
     
     @objc func tapNextBTN() {
         coreDataManager.createPostingData(roomID: roomID!, categoryID: categoryID!, explanation: textContent.text!)
-        imgItems?.forEach {
-            coreDataManager.createPhotoData(postingID: coreDataManager.countData(dataType: "posting") - 1, photoPath: $0.path!)
-        }
+//        imgItems?.forEach {
+//            coreDataManager.createPhotoData(postingID: coreDataManager.countData(dataType: "posting") - 1, photoPath: $0.path!)
+//        }
         self.dismiss(animated: true)
     }
     


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 기존에는 최근에 선택한 이미지가 밑으로 쌓임
- 기존 이미지 선택시 사진 변경만 가능
- 기존에는 ImagePicker와 Phpicker 혼용

## Key Changes 🔥 (주요 구현/변경 사항)
- 최근에 선택한 이미지가 위쪽에 업로드 되도록 수정
- 기존 이미지 선택 시, 이미지 변경 or 이미지 삭제 기능 추가
- Phpicker만 사용
- 이미지를 하나도 선택하지 않을 시, 다음 뷰로 넘어가지 않도록 기능 추가

## ToDo 📆 (남은 작업)
- [ ] HEIF 사진 고려해야 함
- [ ] 기존 이미지를 누르고 싶게 생기도록 UI 변경 필요할 듯
- [ ] 효율적인 코드 고민 필요

## ScreenShot 📷 (참고 사진)
- 플로우 화면
![Simulator Screen Recording - iPhone 14 Pro Max - 2022-11-02 at 11 48 32](https://user-images.githubusercontent.com/92836045/199383720-2a4923fe-71a1-466c-ad18-0bbb142c7651.gif)

- 이미지 불러오는 것을 실패했을 때
![Simulator Screen Recording - iPhone 14 Pro Max - 2022-11-02 at 11 44 39](https://user-images.githubusercontent.com/92836045/199383339-adc37774-cf18-4097-a802-9fbfa6776653.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 코드를 한번에 싹 바꾸느라, 커밋을 제대로 하지 못했습니다. 죄송합니다.
- 로직이 복잡해서 주석을 일단 달았습니다. 머지 직전에 삭제하고 머지하도록 하겠습니다.

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #87 
