### PR TITLE
[Feature] 담당자연락처입력뷰(PhoneNumView) 자동 하이픈(-) 생성 및 번호길이 제한

### DIFF
--- a/Samsam/Global/Extension/PhoneNumberStyle+.swift
+++ b/Samsam/Global/Extension/PhoneNumberStyle+.swift
@@ -13,7 +13,6 @@ extension String {
             if let regex = try? NSRegularExpression(pattern: "([0-9]{4})([0-9]{4})",
                                                     options: .caseInsensitive) {
                 let modString = regex.stringByReplacingMatches(in: self,
-                                                               options: [],
                                                                range: NSRange(self.startIndex..., in: self),
                                                                withTemplate: "$1 - $2")
                 return modString

--- a/Samsam/Global/Extension/PhoneNumberStyle+.swift
+++ b/Samsam/Global/Extension/PhoneNumberStyle+.swift
@@ -1,0 +1,25 @@
+//
+//  PhoneNumberStyle+.swift
+//  Samsam
+//
+//  Created by 지준용 on 2022/11/07.
+//
+
+import UIKit
+
+extension String {
+    func phoneNumberStyle() -> String {
+        if self.count > 7 {
+            if let regex = try? NSRegularExpression(pattern: "([0-9]{4})([0-9]{4})",
+                                                    options: .caseInsensitive) {
+                let modString = regex.stringByReplacingMatches(in: self,
+                                                               options: [],
+                                                               range: NSRange(self.startIndex..., in: self),
+                                                               withTemplate: "$1 - $2")
+                return modString
+            }
+        }
+        return self
+    }
+}
+

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -11,7 +11,7 @@ class PhoneNumViewController: UIViewController {
 
     // MARK: - Property
     
-    var phoneNum = ""
+    private var phoneNum = ""
     
     // MARK: - View
     
@@ -72,6 +72,8 @@ class PhoneNumViewController: UIViewController {
     
     private func attribute() {
         view.backgroundColor = .white
+        
+        numberInput.delegate = self
         numberInput.addTarget(self, action: #selector(buttonAttributeChanged), for: .editingChanged)
         numberInput.addTarget(self, action: #selector(changedNumStyle), for: .editingChanged)
     }
@@ -156,5 +158,14 @@ class PhoneNumViewController: UIViewController {
     @objc private func tapSubmitButton() {
         let roomListViewController = RoomListViewController()
         navigationController?.pushViewController(roomListViewController, animated: true)
+    }
+}
+
+extension PhoneNumViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
+        guard numberInput.text!.count < 9 else { return false }
+        
+        return true
     }
 }

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 
 class PhoneNumViewController: UIViewController {
 
+    // MARK: - Property
+    
+    var phoneNum = ""
+    
     // MARK: - View
     
     private let uiView: UIView = {
@@ -69,6 +73,7 @@ class PhoneNumViewController: UIViewController {
     private func attribute() {
         view.backgroundColor = .white
         numberInput.addTarget(self, action: #selector(buttonAttributeChanged), for: .editingChanged)
+        numberInput.addTarget(self, action: #selector(changedNumStyle), for: .editingChanged)
     }
     
     private func layout() {
@@ -130,6 +135,11 @@ class PhoneNumViewController: UIViewController {
             right: uiView.rightAnchor,
             paddingBottom: 20
         )
+    }
+    
+    @objc func changedNumStyle() {
+        numberInput.text = numberInput.text!.phoneNumberStyle()
+        phoneNum = (numberInput.text?.replacingOccurrences(of: " - ", with: ""))!
     }
 
     @objc private func buttonAttributeChanged() {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 담당자 연락처를 입력받기 위함
- 담당자 연락처를 서버에 전달할 때, 하이픈 없이 전달하기 위함
- 담당자 연락처가 길어지는 것 방지하기 위함.

## Key Changes 🔥 (주요 구현/변경 사항)
- 자동 하이픈(-) 생성
  - 기존: 01012345678
  - 현재: 010 - 1234 - 5678
- 기존 글자수 제한없이 작성되던 번호 수 제한
- 하이픈 없이 받아 서버에 전달할 프로퍼티 생성(phoneNum)

## ToDo 📆 (남은 작업)
- [ ] 해당 뷰는 디자인 외 작업 끝입니다.

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-11-07 at 02 35 14](https://user-images.githubusercontent.com/98405970/200185936-e7790ba7-4a94-4682-b747-90bb04137a02.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 코드입니다. 아마도

## Reference 🔗
- [정규표현식 이해하기](https://baked-corn.tistory.com/136)
- [TextField 글자수 제한 참고자료]( https://kasroid.github.io/posts/ios/20200914-uitextfield-limits-number-of-text-detecting-backspace-event/)
- [ReplacingOccurrences - 애플공식문서](https://developer.apple.com/documentation/foundation/nsstring/1412937-replacingoccurrences)
- [ReplacingOccurrences 참고자료](https://www.zehye.kr/ios/2021/08/11/iOS_replace_string/)

## Close Issues 🔒 (닫을 Issue)
Close #103 .
