### PR TITLE
[Feature] DetailView에서 ImageDetailView로 화면전환 및 ImageDetailView ScrollView로 수정

### DIFF
--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -88,7 +88,6 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     
     private func attribute() {
         view.backgroundColor = .white
-        
         setNavigationBar()
         
         scrollView.delegate = self
@@ -162,12 +161,11 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     }
 
     @objc private func tapShareButton() {
-
         for imgName in images {
             guard let img = UIImage(data: imgName.photoPath!) else { return }
-
             imageArray.append(img)
         }
+        
         let vc = UIActivityViewController(activityItems: imageArray, applicationActivities: [])
         if !imageArray.isEmpty {
             present(vc, animated: true)
@@ -209,6 +207,10 @@ extension DetailViewController {
         let constructionImage = UIImageView()
         constructionImage.image = UIImage(data: img)
         
+        let changedView = UITapGestureRecognizer(target: self, action: #selector(changedView))
+        constructionImage.addGestureRecognizer(changedView)
+        constructionImage.isUserInteractionEnabled = true
+        
         scrollView.addSubview(constructionImage)
         
         constructionImage.frame = CGRect(
@@ -217,5 +219,10 @@ extension DetailViewController {
             width: screenWidth,
             height: screenWidth / 4 * 3
         )
+    }
+    
+    @objc func changedView() {
+        let imageDetailViewController = ImageDetailViewController()
+        navigationController?.pushViewController(imageDetailViewController, animated: true)
     }
 }

--- a/Samsam/ViewController/DetailView/ImageDetailViewController.swift
+++ b/Samsam/ViewController/DetailView/ImageDetailViewController.swift
@@ -9,15 +9,13 @@ import UIKit
 
 class ImageDetailViewController: UIViewController {
     
-    private var isTapped = false
-    
     // MARK: - View
     
-    private let uiView: UIView = {
+    private let scrollView: UIScrollView = {
         return $0
-    }(UIView())
+    }(UIScrollView())
     
-    private let detailImage: UIImageView = {
+    let detailImage: UIImageView = {
         $0.image = UIImage(named: "TestImage")
         $0.contentMode = .scaleAspectFit
         return $0
@@ -34,33 +32,36 @@ class ImageDetailViewController: UIViewController {
     // MARK: - Method
     
     private func layout() {
-        view.addSubview(detailImage)
+        view.addSubview(scrollView)
+        scrollView.addSubview(detailImage)
 
-        detailImage.anchor(
+        scrollView.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor
         )
+        
+        detailImage.anchor(
+            top: scrollView.topAnchor,
+            bottom: scrollView.bottomAnchor
+        )
+        detailImage.centerX(inView: scrollView)
     }
     
     private func attribute() {
         view.backgroundColor = .white
         navigationItem.title = "화장실"
-
+        
+        scrollView.delegate = self
+        scrollView.zoomScale = 1.0
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 3.0
+        scrollView.showsHorizontalScrollIndicator = false
+        
         detailImage.isUserInteractionEnabled = true
-
-        let didPinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(didPinchGesture))
-        detailImage.addGestureRecognizer(didPinchGesture)
-
         let didPanGesture = UIPanGestureRecognizer(target: self, action: #selector(didPanGesture))
         detailImage.addGestureRecognizer(didPanGesture)
-    }
-    
-    @objc private func didPinchGesture(_ sender: UIPinchGestureRecognizer) {
-        detailImage.transform = detailImage.transform.scaledBy(x: sender.scale, y: sender.scale)
-        sender.scale = 1.0
-        detailImage.center = view.center
     }
     
     @objc private func didPanGesture(_ sender: UIPanGestureRecognizer) {
@@ -70,5 +71,19 @@ class ImageDetailViewController: UIViewController {
                                   y: view.center.y + translation.y)
         }
         sender.setTranslation(CGPoint.zero, in: view)
+    }
+}
+
+extension ImageDetailViewController: UIScrollViewDelegate {
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        return detailImage
+    }
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.zoomScale <= 1.0 {
+            scrollView.zoomScale = 1.0
+        }
+        if scrollView.zoomScale >= 3.0 {
+            scrollView.zoomScale = 3.0
+        }
     }
 }

--- a/Samsam/ViewController/DetailView/ImageDetailViewController.swift
+++ b/Samsam/ViewController/DetailView/ImageDetailViewController.swift
@@ -78,12 +78,4 @@ extension ImageDetailViewController: UIScrollViewDelegate {
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         return detailImage
     }
-//    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-//        if scrollView.zoomScale <= 1.0 {
-//            scrollView.zoomScale = 1.0
-//        }
-//        if scrollView.zoomScale >= 3.0 {
-//            scrollView.zoomScale = 3.0
-//        }
-//    }
 }

--- a/Samsam/ViewController/DetailView/ImageDetailViewController.swift
+++ b/Samsam/ViewController/DetailView/ImageDetailViewController.swift
@@ -78,12 +78,12 @@ extension ImageDetailViewController: UIScrollViewDelegate {
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         return detailImage
     }
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.zoomScale <= 1.0 {
-            scrollView.zoomScale = 1.0
-        }
-        if scrollView.zoomScale >= 3.0 {
-            scrollView.zoomScale = 3.0
-        }
-    }
+//    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+//        if scrollView.zoomScale <= 1.0 {
+//            scrollView.zoomScale = 1.0
+//        }
+//        if scrollView.zoomScale >= 3.0 {
+//            scrollView.zoomScale = 3.0
+//        }
+//    }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- DetailView에서 ImageDetailView로 화면전환을 하기 위함
- UX및 앱 완성도를 위한 ImageDetailView 수정

## Key Changes 🔥 (주요 구현/변경 사항)
- DetailView의 ScrollView 내 이미지 클릭 시 화면 전환
- ImageDetailView Zooming 크기 제한
- ImageDetailView View-> ScrollView로 전환하여 PinGesture 제거

## ToDo 📆 (남은 작업)
- [ ] URLSession을 통한 이미지 Get
- [ ] ImageDetailView 화면 센터 수정 및 위치 고정 제거

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-11-17 at 11 14 49](https://user-images.githubusercontent.com/98405970/202337944-03c9fe92-6c51-4486-a388-9f20c18d05a7.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- ^^

## Reference 🔗
- [ScrollView이미지 확대 축소](https://fomaios.tistory.com/entry/iOS-이미지-줌으로-확대축소하기feat-스크롤뷰)

## Close Issues 🔒 (닫을 Issue)
Close #119.
