### PR TITLE
[Feature] 방 생성에 필요한 정보 바인딩 및 초대코드 뷰 연결

### DIFF
--- a/Network/Models/Request/StatusDTO.swift
+++ b/Network/Models/Request/StatusDTO.swift
@@ -10,9 +10,9 @@ import Foundation
 struct StatusDTO: Encodable {
     var roomID: Int
     var category: Int
-    var status: Int? = 0
+    var status: Int?
 
-    init(roomID: Int, category: Int, status: Int? = nil) {
+    init(roomID: Int, category: Int, status: Int? = 0) {
         self.roomID = roomID
         self.category = category
         self.status = status

--- a/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
@@ -25,7 +25,15 @@ class RoomCategoryViewController: UIViewController {
             }
         }
     }
-    var statuses: [Status] = []
+    var statuses: [Status] = [] {
+        didSet {
+            if selectedCellArray.count == statuses.count {
+                let roomCodeViewController = RoomCodeViewController()
+                roomCodeViewController.inviteCode = room!.inviteCode
+                navigationController?.pushViewController(roomCodeViewController, animated: true)
+            }
+        }
+    }
 
     // MARK: - View
 
@@ -153,8 +161,6 @@ class RoomCategoryViewController: UIViewController {
         let roomDTO: RoomDTO = RoomDTO(workerID: workerID, clientName: clientName, startDate: dateFormatter.string(from: startDate), endDate: dateFormatter.string(from: endDate), warrantyTime: warrantyTime)
 
         createRoom(RoomDTO: roomDTO)
-
-        self.dismiss(animated: true)
     }
 }
 

--- a/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
@@ -11,10 +11,11 @@ class RoomCategoryViewController: UIViewController {
 
     // MARK: - Property
 
+    var workerID: Int = 0
     var clientName: String = ""
-    var startingDate: Date = Date()
-    var endingDate: Date = Date()
-    var warrantyTime: Int32 = 0
+    var startDate: String = ""
+    var endDate: String = ""
+    var warrantyTime = 0
     var selectedCellArray: [Int] = []
     let roomAPI: RoomAPI = RoomAPI(apiService: APIService())
     var room: Room? {
@@ -146,7 +147,7 @@ class RoomCategoryViewController: UIViewController {
     @objc func tapNextBTN() {
         selectedCellArray.sort()
 
-        var roomDTO: RoomDTO = RoomDTO(workerID: workerID, clientName: clientName, startDate: startDate, endDate: endDate, warrantyTime: warrantyTime)
+        let roomDTO: RoomDTO = RoomDTO(workerID: workerID, clientName: clientName, startDate: startDate, endDate: endDate, warrantyTime: warrantyTime)
 
         createRoom(RoomDTO: roomDTO)
 

--- a/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
@@ -13,9 +13,9 @@ class RoomCategoryViewController: UIViewController {
 
     var workerID: Int = 0
     var clientName: String = ""
-    var startDate: String = ""
-    var endDate: String = ""
-    var warrantyTime = 0
+    lazy var startDate: Date = Date.now
+    lazy var endDate: Date = Date.now
+    var warrantyTime = 12
     var selectedCellArray: [Int] = []
     let roomAPI: RoomAPI = RoomAPI(apiService: APIService())
     var room: Room? {
@@ -146,8 +146,11 @@ class RoomCategoryViewController: UIViewController {
 
     @objc func tapNextBTN() {
         selectedCellArray.sort()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
 
-        let roomDTO: RoomDTO = RoomDTO(workerID: workerID, clientName: clientName, startDate: startDate, endDate: endDate, warrantyTime: warrantyTime)
+        let roomDTO: RoomDTO = RoomDTO(workerID: workerID, clientName: clientName, startDate: dateFormatter.string(from: startDate), endDate: dateFormatter.string(from: endDate), warrantyTime: warrantyTime)
 
         createRoom(RoomDTO: roomDTO)
 

--- a/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
@@ -11,7 +11,7 @@ class RoomCodeViewController: UIViewController {
 
     // MARK: - Property
 
-    var inviteCode = "000000"
+    var inviteCode = "------"
 
     // MARK: - View
 

--- a/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
@@ -136,7 +136,7 @@ class RoomCodeViewController: UIViewController {
     private func setNavigationTitle() {
         navigationController?.navigationItem.title = "생성 완료"
         navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationController?.setNavigationBarHidden(true, animated: true)
     }
 
     @objc func copyCode() {
@@ -176,6 +176,6 @@ class RoomCodeViewController: UIViewController {
     }
 
     @objc func doneBTN() {
-        navigationController?.popToRootViewController(animated: true)
+        self.dismiss(animated: true)
     }
 }

--- a/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 class RoomCodeViewController: UIViewController {
 
     // MARK: - Property
-    var code = "ASD12d"
 
+    var inviteCode = "000000"
 
     // MARK: - View
 
@@ -41,7 +41,7 @@ class RoomCodeViewController: UIViewController {
     }(UILabel())
 
     private lazy var codeLabel: UILabel = {
-        $0.text = code
+        $0.text = inviteCode
         $0.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         $0.textAlignment = .center
         $0.textColor = .blue
@@ -140,7 +140,7 @@ class RoomCodeViewController: UIViewController {
     }
 
     @objc func copyCode() {
-        UIPasteboard.general.string = code
+        UIPasteboard.general.string = inviteCode
         showToast()
     }
 

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -322,10 +322,8 @@ extension RoomCreationViewController: RoomCreationViewDateFirstCellDelegate {
 
         startDate = strDate
         currentSelectedFirstDate = date
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
-        dateFormatter.locale = Locale(identifier: "ko_KR")
 
-        roomCategoryViewController.startDate = dateFormatter.string(from: date)
+        roomCategoryViewController.startDate = date
         tableView.reloadData()
     }
 }
@@ -339,10 +337,8 @@ extension RoomCreationViewController: RoomCreationViewDateSecondCellDelegate {
 
         endDate = strDate
         currentSelectedSecondDate = date
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
-        dateFormatter.locale = Locale(identifier: "ko_KR")
 
-        roomCategoryViewController.endDate = dateFormatter.string(from: date)
+        roomCategoryViewController.endDate = date
         tableView.reloadData()
     }
 }

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -177,7 +177,9 @@ class RoomCreationViewController: UIViewController{
     }
 
     @objc private func tapNextButton() {
+        roomCategoryViewController.workerID = workerID
         roomCategoryViewController.clientName = customerTextField.text ?? ""
+
         navigationController?.pushViewController(roomCategoryViewController, animated: true)
     }
 
@@ -322,6 +324,10 @@ extension RoomCreationViewController: RoomCreationViewDateFirstCellDelegate {
 
         startDate = strDate
         currentSelectedFirstDate = date
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+
+        roomCategoryViewController.startDate = dateFormatter.string(from: date)
         tableView.reloadData()
     }
 }
@@ -335,6 +341,10 @@ extension RoomCreationViewController: RoomCreationViewDateSecondCellDelegate {
 
         endDate = strDate
         currentSelectedSecondDate = date
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+
+        roomCategoryViewController.endDate = dateFormatter.string(from: date)
         tableView.reloadData()
     }
 }

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -27,7 +27,7 @@ class RoomCreationViewController: UIViewController{
 
     private var startDate = "\(Date.now)"
     private var endDate = "\(Date.now)"
-    
+
     private var currentSelectedFirstDate: Date?
     private var currentSelectedSecondDate: Date?
 
@@ -276,7 +276,7 @@ extension RoomCreationViewController: UITableViewDelegate, UITableViewDataSource
             if indexPath.section == 0 {
                 firstCell.firstDelegate = self
                 firstCell.configure(date: currentSelectedFirstDate)
-                
+
                 setCell(UITableViewCell: firstCell, UIView: firstCell.datePicker)
 
                 return firstCell
@@ -284,7 +284,7 @@ extension RoomCreationViewController: UITableViewDelegate, UITableViewDataSource
             if indexPath.section == 1 {
                 secondCell.secondDelegate = self
                 secondCell.configure(date: currentSelectedSecondDate)
-                
+
                 setCell(UITableViewCell: secondCell, UIView: secondCell.datePicker)
 
                 return secondCell

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -278,7 +278,6 @@ extension RoomCreationViewController: UITableViewDelegate, UITableViewDataSource
                 firstCell.configure(date: currentSelectedFirstDate)
                 
                 setCell(UITableViewCell: firstCell, UIView: firstCell.datePicker)
-                roomCategoryViewController.startingDate = firstCell.datePicker.date
 
                 return firstCell
             }
@@ -287,7 +286,6 @@ extension RoomCreationViewController: UITableViewDelegate, UITableViewDataSource
                 secondCell.configure(date: currentSelectedSecondDate)
                 
                 setCell(UITableViewCell: secondCell, UIView: secondCell.datePicker)
-                roomCategoryViewController.endingDate = secondCell.datePicker.date
 
                 return secondCell
             }

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -17,6 +17,7 @@ class RoomCreationViewController: UIViewController{
 
     // MARK: - Property
 
+    var workerID = 0
     private var tableViewData = [CellData]()
     private let roomCategoryViewController = RoomCategoryViewController()
     private let roomCreationViewDateHeader = RoomCreationViewDateHeader()

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -251,8 +251,8 @@ extension RoomCreationViewController: UITableViewDelegate, UITableViewDataSource
         // MARK: - AS기간
 
         if indexPath.section == 2 {
+            warrantyCell.warrantyTimeDelegate = self
             setCell(UITableViewCell: warrantyCell, UIView: warrantyCell.warrantyView)
-            roomCategoryViewController.warrantyTime = Int32(warrantyCell.warrantyCount)
 
             return warrantyCell
         }
@@ -344,5 +344,11 @@ extension RoomCreationViewController: RoomCreationViewDateSecondCellDelegate {
 
         roomCategoryViewController.endDate = dateFormatter.string(from: date)
         tableView.reloadData()
+    }
+}
+
+extension RoomCreationViewController: RoomCreationViewWarrantyCellDelegate {
+    func warrantyTimeChanged(warrantyTime: Int) {
+        roomCategoryViewController.warrantyTime = warrantyTime
     }
 }

--- a/Samsam/ViewController/RoomCreationView/UIComponent/RoomCreationViewWarrantyCell.swift
+++ b/Samsam/ViewController/RoomCreationView/UIComponent/RoomCreationViewWarrantyCell.swift
@@ -7,10 +7,15 @@
 
 import UIKit
 
+protocol RoomCreationViewWarrantyCellDelegate: AnyObject {
+    func warrantyTimeChanged(warrantyTime: Int)
+}
+
 class RoomCreationViewWarrantyCell: UITableViewCell {
 
     // MARK: - Property
 
+    weak var warrantyTimeDelegate: RoomCreationViewWarrantyCellDelegate?
     static let identifier = "roomCreationViewWarrantyCell"
     var warrantyCount = 12
 
@@ -41,6 +46,7 @@ class RoomCreationViewWarrantyCell: UITableViewCell {
         $0.wraps = true
         $0.autorepeat = true
         $0.addTarget(self, action: #selector(tapStepper), for: .touchUpInside)
+        $0.addTarget(self, action: #selector(changeWarrantyTime), for: .touchUpInside)
         return $0
     }(UIStepper())
 
@@ -105,5 +111,9 @@ class RoomCreationViewWarrantyCell: UITableViewCell {
     @objc private func tapStepper() {
         warrantyCount = Int(warrantyStepper.value)
         warrantyText.text = "\(warrantyCount)개월"
+    }
+    
+    @objc private func changeWarrantyTime() {
+        warrantyTimeDelegate?.warrantyTimeChanged(warrantyTime: Int(warrantyStepper.value))
     }
 }

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -143,7 +143,9 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
     }
 
     @objc func tapRoomCreationButton() {
-        let roomCreationViewController = UINavigationController(rootViewController:  RoomCreationViewController())
+        let roomCreationView = RoomCreationViewController()
+        roomCreationView.workerID = workerID
+        let roomCreationViewController = UINavigationController(rootViewController:  roomCreationView)
         roomCreationViewController.modalPresentationStyle = .fullScreen
         present(roomCreationViewController, animated:  true, completion: nil)
     }

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 class RoomListViewController: UIViewController {
 
     // MARK: - Property
+
+    var workerID = 5
     let roomAPI: RoomAPI = RoomAPI(apiService: APIService())
     var rooms = [Room]() {
         didSet {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 방 생성을 위한 정보를 다음 뷰로 바인딩하기 위함
- 방 생성 후 초대코드 뷰에서 초대코드를 보여주기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- RoomCreationView에서 선택한 방 생성에 필요한 정보를 RoomCategoryView로 바인딩
- Date를 String으로 바인딩 하던 구조를 Date로 바인딩하여 RoomCategoryView에서 String으로 변환하여 서버에 요청하도록 변경
- 방 생성이 완료된 후, 시공 상태까지 완전히 생성이 완료되면 초대코드 뷰로 이동하는 기능 추가
- 초대코드 뷰의 네비게이션 타이틀 히든 처리
- 초대코드 뷰에서 버튼 클릭시 Modal이 Dismiss 되도록 변경

## ToDo 📆 (남은 작업)
- [ ] RoomListView의 workerID를 UserDefaults에서 가져오도록 변경

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/203224757-f0a480ba-edf8-4d19-bbb1-2a21992ad634.gif" width="300">
<img width="330" alt="스크린샷 2022-11-22 13 53 14" src="https://user-images.githubusercontent.com/81027256/203224834-82505cf0-10ed-4012-9435-6f2fe305869a.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 기존에 작성했던 코드만으로는 바인딩이 안되어서 일부 변경된 부분이 있습니다.
- 에디의 Delegate가 바인딩에서 가장 문제가 되는 부분이었으면서도 바인딩을 하기 위해 가장 좋은 솔루션이 되었던 것 같습니다.
- 이번에 에디가 작성한 코드를 보고, 응용해보면서 델리게이트를 어떻게 사용하면 좋을지 배운 것 같아요. 아주 감사합니다.
- RoomListView의 workerID는 시뮬레이터에서 테스트하기 위한 코드입니다. 후에 출시 때에는 UserDefaults에서 따오는 방식으로 변경될 것 입니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #116.
