### PR TITLE
[Feature] 시공상황작성뷰(PostingImageView) 이미지 용량 대폭 감소

### DIFF
--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -79,7 +79,7 @@
 		98C0D07228FD02E400E0E439 /* WorkingHistoryViewContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0D07128FD02E400E0E439 /* WorkingHistoryViewContentCell.swift */; };
 		98C2448B28FD3EDA0006A01B /* WorkingHistoryViewTopHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C2448A28FD3EDA0006A01B /* WorkingHistoryViewTopHeader.swift */; };
 		98CFE3122910FC8E004B2FA1 /* InquiryHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CFE3112910FC8E004B2FA1 /* InquiryHistoryViewController.swift */; };
-		98E1700D2906EFEB00F71D41 /* hideKeyboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */; };
+		98E1700D2906EFEB00F71D41 /* HideKeyboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E1700C2906EFEB00F71D41 /* HideKeyboard+.swift */; };
 		98E1700F29080C9100F71D41 /* ImageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E1700E29080C9100F71D41 /* ImageDetailViewController.swift */; };
 		98E899BA290FCAAB001245C4 /* WorkingHistoryViewContentHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E899B9290FCAAB001245C4 /* WorkingHistoryViewContentHeader.swift */; };
 		98E899BC290FD00C001245C4 /* WorkingHistoryViewTopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E899BB290FD00C001245C4 /* WorkingHistoryViewTopCell.swift */; };
@@ -161,7 +161,7 @@
 		98C0D07128FD02E400E0E439 /* WorkingHistoryViewContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewContentCell.swift; sourceTree = "<group>"; };
 		98C2448A28FD3EDA0006A01B /* WorkingHistoryViewTopHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewTopHeader.swift; sourceTree = "<group>"; };
 		98CFE3112910FC8E004B2FA1 /* InquiryHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryHistoryViewController.swift; sourceTree = "<group>"; };
-		98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "hideKeyboard+.swift"; sourceTree = "<group>"; };
+		98E1700C2906EFEB00F71D41 /* HideKeyboard+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HideKeyboard+.swift"; sourceTree = "<group>"; };
 		98E1700E29080C9100F71D41 /* ImageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailViewController.swift; sourceTree = "<group>"; };
 		98E899B9290FCAAB001245C4 /* WorkingHistoryViewContentHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewContentHeader.swift; sourceTree = "<group>"; };
 		98E899BB290FD00C001245C4 /* WorkingHistoryViewTopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingHistoryViewTopCell.swift; sourceTree = "<group>"; };
@@ -377,7 +377,7 @@
 			isa = PBXGroup;
 			children = (
 				98C0D05F28FCE8EB00E0E439 /* AutoLayout+.swift */,
-				98E1700C2906EFEB00F71D41 /* hideKeyboard+.swift */,
+				98E1700C2906EFEB00F71D41 /* HideKeyboard+.swift */,
 				98B08A5F290AC8C900401650 /* UIColor+.swift */,
 				9866F51529189AEE002D3589 /* PhoneNumberStyle+.swift */,
 			);
@@ -541,7 +541,7 @@
 				431F0778291DEBB7004FC4B6 /* Encodable.swift in Sources */,
 				431F0767291DEB90004FC4B6 /* LoginDTO.swift in Sources */,
 				431F0769291DEB9B004FC4B6 /* LoginEndPoint.swift in Sources */,
-				98E1700D2906EFEB00F71D41 /* hideKeyboard+.swift in Sources */,
+				98E1700D2906EFEB00F71D41 /* HideKeyboard+.swift in Sources */,
 				98C0D06C28FCF46500E0E439 /* WorkingHistoryViewController.swift in Sources */,
 				26FEC1E02902E6F2006C410B /* PhotoEntity+CoreDataProperties.swift in Sources */,
 				98C0D06728FCE9DC00E0E439 /* Model.swift in Sources */,

--- a/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
+++ b/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
@@ -85,7 +85,7 @@ class SegmentedControlViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        loadPostByRoom(roomID: room!.roomID)
+        loadPostByRoomID(roomID: room!.roomID)
     }
 
     // MARK: - Method

--- a/Samsam/ViewController/PostingView/PostingImageCell.swift
+++ b/Samsam/ViewController/PostingView/PostingImageCell.swift
@@ -12,11 +12,12 @@ class PostingImageCell: UICollectionViewCell {
     // MARK: - Property
 
     static let identifier = "PostingImageCell"
+    var previewData: Data = (UIImage(named: "GrayBox")?.jpegData(compressionQuality: 1.0))!
 
     // MARK: - View
 
-    var preview: UIImageView = {
-        $0.image = UIImage(named: "Test01")
+    lazy var preview: UIImageView = {
+        $0.image = UIImage(data: previewData)
         $0.clipsToBounds = true
         $0.contentMode = .scaleAspectFill
         $0.layer.cornerRadius = 16

--- a/Samsam/ViewController/PostingView/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingImageViewController.swift
@@ -236,7 +236,6 @@ class PostingImageViewController: UIViewController {
             scale = newWidth / image.size.width
             newHeight = image.size.height * scale
         } else {
-            scale = 1.0
             newHeight = image.size.height
         }
         UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))

--- a/Samsam/ViewController/PostingView/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingImageViewController.swift
@@ -342,12 +342,12 @@ extension PostingImageViewController: UICollectionViewDataSource, UICollectionVi
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let cellWidth =  310
-        let cellHeight = 235
+        let cellWidth = UIScreen.main.bounds.width - 32
+        let cellHeight = (UIScreen.main.bounds.width - 32) / 4 * 3
         return CGSize(width: cellWidth, height: cellHeight)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 8, left: 8, bottom: 16, right: 8)
+        return UIEdgeInsets(top: 8, left: 8, bottom: 0, right: 8)
     }
 }

--- a/Samsam/ViewController/PostingView/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingImageViewController.swift
@@ -327,9 +327,9 @@ extension PostingImageViewController: UICollectionViewDataSource, UICollectionVi
             let buttonCell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingImageButtonCell.identifier, for: indexPath) as! PostingImageButtonCell
             return buttonCell
         } else {
-            let imagecell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingImageCell.identifier, for: indexPath) as! PostingImageCell
-            imagecell.preview.image = photoImages[indexPath.row].image
-            return imagecell
+            let imageCell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingImageCell.identifier, for: indexPath) as! PostingImageCell
+            imageCell.preview.image = UIImage(data: photoImages[indexPath.row].path!)
+            return imageCell
         }
     }
 

--- a/Samsam/ViewController/PostingView/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingImageViewController.swift
@@ -232,17 +232,17 @@ class PostingImageViewController: UIViewController {
     private func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
         var scale = 0.0
         var newHeight = 0.0
+
         if newWidth < image.size.width {
             scale = newWidth / image.size.width
             newHeight = image.size.height * scale
-        } else {
-            newHeight = image.size.height
+            UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))
+            image.draw(in: CGRectMake(0, 0, newWidth, newHeight))
+            let newImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            return newImage!
         }
-        UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))
-        image.draw(in: CGRectMake(0, 0, newWidth, newHeight))
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return newImage!
+        return image
     }
 
     @objc func uploadPhoto() {
@@ -285,10 +285,10 @@ extension PostingImageViewController: PHPickerViewControllerDelegate {
                         guard let image = image as? UIImage else { return }
                         if self?.changeNUM == -1 {
                             self?.photoImages.insert(CellItem(image: image,
-                                                              path: self!.resizeImage(image: image, newWidth: UIScreen.main.bounds.width).jpegData(compressionQuality: 1.0)), at: 0)
+                                                              path: self!.resizeImage(image: image, newWidth: 800).jpegData(compressionQuality: 1.0)), at: 0)
                         } else {
                             self?.photoImages[self!.changeNUM] = CellItem(image: image,
-                                                                          path: self!.resizeImage(image: image, newWidth: UIScreen.main.bounds.width).jpegData(compressionQuality: 1.0))
+                                                                          path: self!.resizeImage(image: image, newWidth: 800).jpegData(compressionQuality: 1.0))
                         }
                         self?.imageCellView.reloadData()
                     }

--- a/Samsam/ViewController/PostingView/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingImageViewController.swift
@@ -230,8 +230,15 @@ class PostingImageViewController: UIViewController {
     }
     
     private func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
-        let scale = newWidth / image.size.width
-        let newHeight = image.size.height * scale
+        var scale = 0.0
+        var newHeight = 0.0
+        if newWidth < image.size.width {
+            scale = newWidth / image.size.width
+            newHeight = image.size.height * scale
+        } else {
+            scale = 1.0
+            newHeight = image.size.height * scale
+        }
         UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))
         image.draw(in: CGRectMake(0, 0, newWidth, newHeight))
         let newImage = UIGraphicsGetImageFromCurrentImageContext()

--- a/Samsam/ViewController/PostingView/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingImageViewController.swift
@@ -228,6 +228,16 @@ class PostingImageViewController: UIViewController {
 
         present(alert, animated: true, completion: nil)
     }
+    
+    private func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
+        let scale = newWidth / image.size.width
+        let newHeight = image.size.height * scale
+        UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))
+        image.draw(in: CGRectMake(0, 0, newWidth, newHeight))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage!
+    }
 
     @objc func uploadPhoto() {
         changeNUM = -1
@@ -268,9 +278,11 @@ extension PostingImageViewController: PHPickerViewControllerDelegate {
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
                         if self?.changeNUM == -1 {
-                            self?.photoImages.insert(CellItem(image: image, path: image.pngData()), at: 0)
+                            self?.photoImages.insert(CellItem(image: image,
+                                                              path: self!.resizeImage(image: image, newWidth: UIScreen.main.bounds.width).jpegData(compressionQuality: 1.0)), at: 0)
                         } else {
-                            self?.photoImages[self!.changeNUM] = CellItem(image: image, path: image.pngData())
+                            self?.photoImages[self!.changeNUM] = CellItem(image: image,
+                                                                          path: self!.resizeImage(image: image, newWidth: UIScreen.main.bounds.width).jpegData(compressionQuality: 1.0))
                         }
                         self?.imageCellView.reloadData()
                     }

--- a/Samsam/ViewController/PostingView/PostingImageViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingImageViewController.swift
@@ -237,7 +237,7 @@ class PostingImageViewController: UIViewController {
             newHeight = image.size.height * scale
         } else {
             scale = 1.0
-            newHeight = image.size.height * scale
+            newHeight = image.size.height
         }
         UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))
         image.draw(in: CGRectMake(0, 0, newWidth, newHeight))


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 서버 부하 감소를 위한 이미지 조정

## Key Changes 🔥 (주요 구현/변경 사항)
- 제가 이해한 UIGraphicsBeginImageContext()는 이미지를 새롭게 그린다 라고 이해했습니다.
  - UIGraphicsBeginImageContext(_ size: CGSize) -> 해당 사이즈로 반환 및 작업 시작
  - UIGraphicsGetImageFromCurrentImageContext() -> 현재 반영된 사항을 UIImage 타입으로 불러내기 위한 함수
  - UIGraphicsEndImageContext() -> 작업 종료
- 저는 이렇게 이해했고, 자세한 내용은 애플공식문서를 참고하시면 될 것 같습니다.
- 용량을 10MB이하로 변환하는 작업은 아니지만, (기본 라이브러리 이미지 기준) 기존보다 1/10 이상으로 줄였기에 단순히 용량제한을 거는 것보다 유의미하다 판단해 PR을 올렸습니다.(MB기준: 6MB -> 0.5MB)

```swift
    private func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
        let scale = newWidth / image.size.width
        let newHeight = image.size.height * scale
        UIGraphicsBeginImageContext(CGSizeMake(newWidth, newHeight))
        image.draw(in: CGRectMake(0, 0, newWidth, newHeight))
        let newImage = UIGraphicsGetImageFromCurrentImageContext()
        UIGraphicsEndImageContext()
        return newImage!
    }
```

## ToDo 📆 (남은 작업)
- [ ] .gif확장자 업로드 방지

## ScreenShot 📷 (참고 사진)
![스크린샷 2022-11-25 오후 11 41 15](https://user-images.githubusercontent.com/98405970/204007673-6b661169-b0e1-4f2a-8819-aaa20ec9f3bf.png)
![스크린샷 2022-11-25 오후 11 40 39](https://user-images.githubusercontent.com/98405970/204007563-ae5bce89-27af-45be-8e68-00b2baa55ed2.png)

- 상단이 기존 내용이며, 하단이 수정된 내용입니다.

![Simulator Screen Recording - iPhone 13 Pro - 2022-11-25 at 23 22 11](https://user-images.githubusercontent.com/98405970/204004522-201c9a8d-7fde-4acf-a23a-fae2580383bd.gif)
- 레이아웃을 일부 수정했습니다.
  - 상하패딩이 일정하지 않았던 점 -> bottom padding 0으로 수정
  - 이미지 사이즈가 고정되어있던 점  -> ImageSize 동적으로 변경

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- [UIGraphicsBeginImageContext - Apple공식문서](https://developer.apple.com/documentation/uikit/1623922-uigraphicsbeginimagecontext)
- [UIGraphicsGetImageFromCurrentImageContext - Apple공식문서](https://developer.apple.com/documentation/uikit/1623924-uigraphicsgetimagefromcurrentima)
- [UIGraphicsGetImageFromCurrentImageContext - Apple공식문서](https://developer.apple.com/documentation/uikit/1623924-uigraphicsgetimagefromcurrentima)
- [JPG vs PNG](https://blogchannel.tistory.com/269)
  - JPG는 손실압축방식.-> 거슬리지 않을정도로 원본을 훼손하여 압축하기 때문에 압축률이 좋음.
  - PNG는 비손실압축방식 -> 원본이 훼손되지 않음. 최대한 실사에 가까운 이미지를 유지하기 좋음


## Close Issues 🔒 (닫을 Issue)
Close #135 .
