### PR TITLE
[Feature] 세부시공상태뷰(Detailview) 이미지 및 텍스트 데이터 바인딩 및 공유 기능

### DIFF
--- a/Samsam/Global/SceneDelegate.swift
+++ b/Samsam/Global/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        let navi = UINavigationController(rootViewController: ViewController())
+        let navi = UINavigationController(rootViewController: RoomListViewController())
         window?.rootViewController = navi
         window?.makeKeyAndVisible()
     }

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -221,7 +221,7 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let detailViewController = DetailViewController()
         coreDataManager.loadPhotoData(postingID: Int(coreDataManager.postings[indexPath.item].postingID))
-        detailViewController.images = coreDataManager.photos
+//        detailViewController.images = coreDataManager.photos
         coreDataManager.postings.forEach {
             if $0 == coreDataManager.postings[indexPath.item] {
                 detailViewController.descriptionLBL.text = $0.explanation

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -148,19 +148,19 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         pageControl.currentPage = Int(scrollView.contentOffset.x / screenWidth)
     }
 
-    @objc private func pageDidChange(sender: UIPageControl){
+    @objc func pageDidChange(sender: UIPageControl){
         let offsetX = screenWidth * CGFloat(pageControl.currentPage)
         scrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
     }
 
     // TODO: - 수정화면 생성되면 수정예정.
 
-    @objc private func tapEditButton() {
+    @objc func tapEditButton() {
         let editViewController = ViewController()
         navigationController?.pushViewController(editViewController, animated: true)
     }
 
-    @objc private func tapShareButton() {
+    @objc func tapShareButton() {
         sharingItems = []
         DispatchQueue.global().async {
             self.appendImage()
@@ -171,7 +171,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         }
     }
 
-    func appendImage() {
+    private func appendImage() {
         images.forEach {
             let imageData = try? Data(contentsOf: URL(string: $0.photoPath)!)
             DispatchQueue.main.sync {
@@ -181,7 +181,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         }
     }
     
-    func shareitems() {
+    private func shareitems() {
         let vc = UIActivityViewController(activityItems: self.sharingItems, applicationActivities: [])
         self.present(vc, animated: true)
     }

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -15,7 +15,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 
     private var naviTitle = "화장실"
     var images: [Photo] = []
-    private var imageArray: [UIImage] = []
+    private var sharingItems: [Any] = []
 
     // MARK: - View
 
@@ -92,7 +92,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 
         scrollView.delegate = self
         pageControl.addTarget(self, action: #selector(pageDidChange(sender: )), for: .valueChanged)
-        sharingButton.addTarget(self, action: #selector(tapShareButton), for: .touchUpInside)        
+        sharingButton.addTarget(self, action: #selector(tapShareButton), for: .touchUpInside)
     }
 
     private func layout() {
@@ -161,30 +161,28 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     }
 
     @objc private func tapShareButton() {
-        imageArray = []
-        
+        sharingItems = []
         DispatchQueue.global().async {
-            self.images.forEach {
-                let imageData = try? Data(contentsOf: URL(string: $0.photoPath)!)
-                
-                DispatchQueue.main.sync {
-                    self.appendImage(imageData: imageData!)
-                }
-                
-                DispatchQueue.main.sync {
-                    self.shareImage()
-                }
+            self.appendImage()
+            DispatchQueue.main.sync {
+                self.sharingItems.append(self.descriptionLBL.text!)
+                self.shareitems()
             }
         }
     }
 
-    func appendImage(imageData: Data) {
-        guard let image = UIImage(data: imageData) else { return }
-        self.imageArray.append(image)
+    func appendImage() {
+        images.forEach {
+            let imageData = try? Data(contentsOf: URL(string: $0.photoPath)!)
+            DispatchQueue.main.sync {
+                guard let image = UIImage(data: imageData!) else { return }
+                self.sharingItems.append(image)
+            }
+        }
     }
     
-    func shareImage() {
-        let vc = UIActivityViewController(activityItems: self.imageArray, applicationActivities: [])
+    func shareitems() {
+        let vc = UIActivityViewController(activityItems: self.sharingItems, applicationActivities: [])
         self.present(vc, animated: true)
     }
     

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -89,6 +89,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     private func attribute() {
         view.backgroundColor = .white
         setNavigationBar()
+        sharingItems.append(self.descriptionLBL.text!)
 
         scrollView.delegate = self
         pageControl.addTarget(self, action: #selector(pageDidChange(sender: )), for: .valueChanged)
@@ -161,31 +162,9 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     }
 
     @objc func tapShareButton() {
-        sharingItems = []
-        DispatchQueue.global().async {
-            self.appendImage()
-            DispatchQueue.main.sync {
-                self.sharingItems.append(self.descriptionLBL.text!)
-                self.shareitems()
-            }
-        }
-    }
-
-    private func appendImage() {
-        images.forEach {
-            let imageData = try? Data(contentsOf: URL(string: $0.photoPath)!)
-            DispatchQueue.main.sync {
-                guard let image = UIImage(data: imageData!) else { return }
-                self.sharingItems.append(image)
-            }
-        }
-    }
-    
-    private func shareitems() {
         let vc = UIActivityViewController(activityItems: self.sharingItems, applicationActivities: [])
         self.present(vc, animated: true)
     }
-    
 }
 
 // MARK: - configuratingScrollView
@@ -216,8 +195,12 @@ extension DetailViewController {
         for num in 0..<images.count {
             DispatchQueue.global().async {
                 let imageData = try? Data(contentsOf: URL(string: self.images[num].photoPath)!)
+                
                 DispatchQueue.main.async {
                     self.addImageView(img: imageData!, position: CGFloat(num))
+                    
+                    guard let image = UIImage(data: imageData!) else { return }
+                    self.sharingItems.append(image)
                 }
             }
         }

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -92,7 +92,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         sharingItems.append(self.descriptionLBL.text!)
 
         scrollView.delegate = self
-        pageControl.addTarget(self, action: #selector(pageDidChange(sender: )), for: .valueChanged)
+        pageControl.addTarget(self, action: #selector(pageDidChange), for: .valueChanged)
         sharingButton.addTarget(self, action: #selector(tapShareButton), for: .touchUpInside)
     }
 

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -92,7 +92,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 
         scrollView.delegate = self
         pageControl.addTarget(self, action: #selector(pageDidChange(sender: )), for: .valueChanged)
-//        sharingButton.addTarget(self, action: #selector(tapShareButton), for: .touchUpInside)
+        sharingButton.addTarget(self, action: #selector(tapShareButton), for: .touchUpInside)        
     }
 
     private func layout() {
@@ -160,17 +160,34 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         navigationController?.pushViewController(editViewController, animated: true)
     }
 
-//    @objc private func tapShareButton() {
-//        for imgName in images {
-//            guard let img = UIImage(data: imgName.photoPath!) else { return }
-//            imageArray.append(img)
-//        }
-//
-//        let vc = UIActivityViewController(activityItems: imageArray, applicationActivities: [])
-//        if !imageArray.isEmpty {
-//            present(vc, animated: true)
-//        }
-//    }
+    @objc private func tapShareButton() {
+        imageArray = []
+        
+        DispatchQueue.global().async {
+            self.images.forEach {
+                let imageData = try? Data(contentsOf: URL(string: $0.photoPath)!)
+                
+                DispatchQueue.main.sync {
+                    self.appendImage(imageData: imageData!)
+                }
+                
+                DispatchQueue.main.sync {
+                    self.shareImage()
+                }
+            }
+        }
+    }
+
+    func appendImage(imageData: Data) {
+        guard let image = UIImage(data: imageData) else { return }
+        self.imageArray.append(image)
+    }
+    
+    func shareImage() {
+        let vc = UIActivityViewController(activityItems: self.imageArray, applicationActivities: [])
+        self.present(vc, animated: true)
+    }
+    
 }
 
 // MARK: - configuratingScrollView

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -14,7 +14,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     let screenWidth = UIScreen.main.bounds.width - 32
 
     private var naviTitle = "화장실"
-    var images: [PhotoEntity] = []
+    var images: [Photo] = []
     private var imageArray: [UIImage] = []
 
     // MARK: - View
@@ -92,7 +92,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 
         scrollView.delegate = self
         pageControl.addTarget(self, action: #selector(pageDidChange(sender: )), for: .valueChanged)
-        sharingButton.addTarget(self, action: #selector(tapShareButton), for: .touchUpInside)
+//        sharingButton.addTarget(self, action: #selector(tapShareButton), for: .touchUpInside)
     }
 
     private func layout() {
@@ -160,17 +160,17 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         navigationController?.pushViewController(editViewController, animated: true)
     }
 
-    @objc private func tapShareButton() {
-        for imgName in images {
-            guard let img = UIImage(data: imgName.photoPath!) else { return }
-            imageArray.append(img)
-        }
-
-        let vc = UIActivityViewController(activityItems: imageArray, applicationActivities: [])
-        if !imageArray.isEmpty {
-            present(vc, animated: true)
-        }
-    }
+//    @objc private func tapShareButton() {
+//        for imgName in images {
+//            guard let img = UIImage(data: imgName.photoPath!) else { return }
+//            imageArray.append(img)
+//        }
+//
+//        let vc = UIActivityViewController(activityItems: imageArray, applicationActivities: [])
+//        if !imageArray.isEmpty {
+//            present(vc, animated: true)
+//        }
+//    }
 }
 
 // MARK: - configuratingScrollView
@@ -199,7 +199,12 @@ extension DetailViewController {
         )
 
         for num in 0..<images.count {
-            addImageView(img: images[num].photoPath!, position: CGFloat(num))
+            DispatchQueue.global().async {
+                let imageData = try? Data(contentsOf: URL(string: self.images[num].photoPath)!)
+                DispatchQueue.main.async {
+                    self.addImageView(img: imageData!, position: CGFloat(num))
+                }
+            }
         }
     }
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -143,16 +143,11 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section > 0 {
             let detailViewController = DetailViewController()
+            detailViewController.descriptionLBL.text = posts[indexPath.item].description
             
-            // TODO: - 이미지 및 설명 클릭 시 데이터 바인딩
-            
-//            coreDataManager.loadPhotoData(postingID: Int(coreDataManager.postings[indexPath.item].postingID))
-//            detailViewController.images = coreDataManager.photos
-//            coreDataManager.postings.forEach {
-//                if $0 == coreDataManager.postings[indexPath.item] {
-//                    detailViewController.descriptionLBL.text = $0.explanation
-//                }
-//            }
+            posts[indexPath.item].photos!.forEach {
+                detailViewController.images.append($0)
+            }
             navigationController?.pushViewController(detailViewController, animated: true)
         }
     }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 시공상황뷰(WorkingHistory)에서 받은 서버데이터를 세부시공상태뷰(DetailView)로 바인딩 하기 위함
- 바인딩 받은 데이터를 공유하기 위함
- 초기화면 수정

## Key Changes 🔥 (주요 구현/변경 사항)
- 시공상황뷰(WorkingHistory)에서 받은 서버데이터를 세부시공상태뷰(DetailView)로 바인딩
- 바인딩 받은 이미지, 텍스트 데이터 공유하기 기능 수정 ( 기존 코어데이터 -> 서버(바인딩) 데이터 )
  - ` let imageData = try? Data(contentsOf: URL(string: $0.photoPath)!)`는 main thread가 아닌 곳에서 비동기 처리가 되어야 함
  - image가 모두 append된 이후에 sharing(공유) 기능이 실행되어야 함
- 초기화면 RoomListViewController로 수정하였습니다.

## ToDo 📆 (남은 작업)
- [ ] 세부이미지뷰(ImageDetailView)로 이미지 바인딩

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-01 at 04 05 01](https://user-images.githubusercontent.com/98405970/204886277-11b06a3a-014e-4571-955f-d965ca2ffe1a.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 비동기 내에서 동기처리하는 작업에 난항을 겪어 생각보다 시간이 많이 걸렸습니다. ㅠㅠ

## Reference 🔗
- [main.sync를 사용하지 않는 이유](https://zeddios.tistory.com/519)
- [iOS 비동기처리방식](https://medium.com/@goehd2538/ios의-비동기-처리방식-65aa81aad0f9)
- [DispatchQueue사용법](https://zeddios.tistory.com/516)

## Close Issues 🔒 (닫을 Issue)
Close #141.
