### PR TITLE
[Feature] 카테고리별시공상황(ChipView)로 데이터 바인딩

### DIFF
--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -219,7 +219,6 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
                     contentCell.workType.text = Category(rawValue: Int(self.posts[indexPath.item].category))?.categoryName()
                 }
             }
-            return contentCell
         } else {
             DispatchQueue.global().async {
                 let data = try? Data(contentsOf: URL(string: self.selectedPosts[indexPath.item].photos![0].photoPath)!)
@@ -230,7 +229,6 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
                     contentCell.workType.text = Category(rawValue: Int(self.selectedPosts[indexPath.item].category))?.categoryName()
                 }
             }
-            return contentCell
         }
         return contentCell
     }

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -14,15 +14,12 @@ class ChipViewController: UIViewController {
     var room: Room?
     var posts: [Post] = []
     var statuses: [Status]?
-
     var selectedPosts: [Post] = []
     
-    var roomID: Int?
     private var chips: [UIButton] = []
     var categoryID: Int = 0
     private var categoryArray: [Int] = []
     private var selectedID: Int = 0
-    private var selectedCategoryItem: [PostingEntity] = []
 
     // MARK: - View
 
@@ -64,12 +61,7 @@ class ChipViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        // TODO: - 칩뷰 데이터(이미지, 설명, 칩 정보) 로드
-        
-//        coreDataManager.loadOneRoomData(roomID: roomID!)
-//        coreDataManager.loadPostingData(roomID: roomID!)
-//        coreDataManager.loadWorkingStatusData(roomID: roomID!)
+
         historyView.reloadData()
     }
 
@@ -170,7 +162,6 @@ class ChipViewController: UIViewController {
             unselectedButton(UIButton: chips[selectedID])
             selectedID = sender.tag
             selectedButton(UIButton: chips[selectedID])
-            selectedCategoryItem = []
             historyView.reloadData()
         }
     }

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -209,7 +209,7 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
 
         let contentCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewContentCell.identifier, for: indexPath) as! WorkingHistoryViewContentCell
         
-        if self.selectedID == 0 {
+        if selectedID == 0 {
             DispatchQueue.global().async {
                 let data = try? Data(contentsOf: URL(string: self.posts[indexPath.item].photos![0].photoPath)!)
                 
@@ -241,20 +241,22 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-//        let detailViewController = DetailViewController()
-//        detailViewController.images = posts![indexPath.item].photos!
-//        posts?.forEach {
-//            if $0 == posts![indexPath.item] {
-//                detailViewController.descriptionLBL.text = $0.description
-//            }
-//        }
-//        coreDataManager.loadPhotoData(postingID: Int(coreDataManager.postings[indexPath.item].postingID))
-//        detailViewController.images = coreDataManager.photos
-//        coreDataManager.postings.forEach {
-//            if $0 == coreDataManager.postings[indexPath.item] {
-//                detailViewController.descriptionLBL.text = $0.explanation
-//            }
-//        }
-//        navigationController?.pushViewController(detailViewController, animated: true)
+        let detailViewController = DetailViewController()
+        
+        if selectedID == 0 {
+            detailViewController.descriptionLBL.text = posts[indexPath.item].description
+            
+            posts[indexPath.item].photos!.forEach {
+                detailViewController.images.append($0)
+            }
+        } else {
+            detailViewController.descriptionLBL.text = selectedPosts[indexPath.item].description
+            
+            selectedPosts[indexPath.item].photos!.forEach {
+                detailViewController.images.append($0)
+            }
+        }
+        
+        navigationController?.pushViewController(detailViewController, animated: true)
     }
 }

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -18,7 +18,6 @@ class ChipViewController: UIViewController {
     
     private var chips: [UIButton] = []
     var categoryID: Int = 0
-    private var categoryArray: [Int] = []
     private var selectedID: Int = 0
 
     // MARK: - View
@@ -131,9 +130,7 @@ class ChipViewController: UIViewController {
         chips.append(makeButton(title: "  전체  ", tag: 0))
 
         for i in stride(from: 1, to: statuses!.count + 1, by: 1) {
-            chips.append(makeButton(title: "  " + (Category(rawValue: Int(statuses![i-1].category))?.categoryName())! + "  ", tag: i))
-            categoryArray.append(Int(statuses![i-1].category))
-        }
+            chips.append(makeButton(title: "  " + (Category(rawValue: Int(statuses![i-1].category))?.categoryName())! + "  ", tag: i))        }
 
         chips.forEach {
             chipContentView.addArrangedSubview($0)
@@ -187,7 +184,7 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
             selectedPosts = []
             
             posts.forEach {
-                if $0.category == categoryArray[selectedID - 1] {
+                if $0.category == statuses![selectedID - 1].category{
                     selectedPosts.append($0)
                 }
             }

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -193,7 +193,7 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
             }
             return selectedPosts.count
         }
-        return 1
+        return 0
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -200,27 +200,18 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
 
         let contentCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewContentCell.identifier, for: indexPath) as! WorkingHistoryViewContentCell
         
-        if selectedID == 0 {
-            DispatchQueue.global().async {
-                let data = try? Data(contentsOf: URL(string: self.posts[indexPath.item].photos![0].photoPath)!)
-                
-                DispatchQueue.main.async {
-                    contentCell.uiImageView.image = UIImage(data: data!)
-                    contentCell.imageDescription.text = self.posts[indexPath.item].description
-                    contentCell.workType.text = Category(rawValue: Int(self.posts[indexPath.item].category))?.categoryName()
-                }
-            }
-        } else {
-            DispatchQueue.global().async {
-                let data = try? Data(contentsOf: URL(string: self.selectedPosts[indexPath.item].photos![0].photoPath)!)
-                
-                DispatchQueue.main.async {
-                    contentCell.uiImageView.image = UIImage(data: data!)
-                    contentCell.imageDescription.text = self.selectedPosts[indexPath.item].description
-                    contentCell.workType.text = Category(rawValue: Int(self.selectedPosts[indexPath.item].category))?.categoryName()
-                }
+        let selectedArray = (selectedID == 0 ? posts : selectedPosts)
+        
+        DispatchQueue.global().async {
+            let data = try? Data(contentsOf: URL(string: selectedArray[indexPath.item].photos![0].photoPath)!)
+            
+            DispatchQueue.main.async {
+                contentCell.uiImageView.image = UIImage(data: data!)
+                contentCell.imageDescription.text = selectedArray[indexPath.item].description
+                contentCell.workType.text = Category(rawValue: Int(selectedArray[indexPath.item].category))?.categoryName()
             }
         }
+        
         return contentCell
     }
 
@@ -233,19 +224,13 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let detailViewController = DetailViewController()
+
+        let selectedArray = (selectedID == 0 ? posts : selectedPosts)
         
-        if selectedID == 0 {
-            detailViewController.descriptionLBL.text = posts[indexPath.item].description
-            
-            posts[indexPath.item].photos!.forEach {
-                detailViewController.images.append($0)
-            }
-        } else {
-            detailViewController.descriptionLBL.text = selectedPosts[indexPath.item].description
-            
-            selectedPosts[indexPath.item].photos!.forEach {
-                detailViewController.images.append($0)
-            }
+        detailViewController.descriptionLBL.text = selectedArray[indexPath.item].description
+        
+        selectedArray[indexPath.item].photos!.forEach {
+            detailViewController.images.append($0)
         }
         
         navigationController?.pushViewController(detailViewController, animated: true)

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -168,6 +168,8 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     @objc func tapAllView() {
         let chipViewController = ChipViewController()
         chipViewController.room = room
+        chipViewController.posts = posts
+        chipViewController.statuses = statuses
         navigationController?.pushViewController(chipViewController , animated: true)
     }
 }

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -11,6 +11,8 @@ class WorkingHistoryViewController: UIViewController {
 
     // MARK: - Property
     
+    let roomAPI: RoomAPI = RoomAPI(apiService: APIService())
+    var statuses: [Status]?
     var posts = [Post]() {
         didSet {
             workingHistoryView.reloadData()
@@ -36,6 +38,7 @@ class WorkingHistoryViewController: UIViewController {
         super.viewDidLoad()
         attribute()
         layout()
+        loadStatusesByRoomID(roomID: room!.roomID)
     }
 
     // MARK: - Method
@@ -61,6 +64,16 @@ class WorkingHistoryViewController: UIViewController {
             bottom: view.bottomAnchor,
             right: view.rightAnchor
         )
+    }
+    
+    func loadStatusesByRoomID(roomID: Int) {
+        Task {
+            let response = try await self.roomAPI.loadStatusesByRoomID(roomID: room!.roomID)
+            guard let data = response else {
+                return
+            }
+            statuses = data
+        }
     }
 }
 

--- a/Samsam/ViewController/PostingView/PostingCategoryViewController.swift
+++ b/Samsam/ViewController/PostingView/PostingCategoryViewController.swift
@@ -13,9 +13,8 @@ class PostingCategoryViewController: UIViewController {
     
     var roomID: Int?
     var room: Room?
-    var roomCategoryID: [Int] = []
     private var roomAPI: RoomAPI = RoomAPI(apiService: APIService())
-    private var categoryID: Int = 0
+    var categoryID: Int = 0
     
     private var status: [Status]? {
         didSet {
@@ -113,7 +112,7 @@ class PostingCategoryViewController: UIViewController {
         Task {
             let response = try await self.roomAPI.loadStatusesByRoomID(roomID: room!.roomID)
             guard let data = response else {
-                return 
+                return
             }
             status = data
         }

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -132,11 +132,11 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
         cell.endDate.text = convertDate(dateString: rooms[indexPath.row].endDate)
         return cell
     }
-
+    
     func convertDate(dateString: String) -> String {
-        let year = dateString.dropFirst(2).dropLast(20)
-        let month = dateString.dropFirst(5).dropLast(17)
-        let day = dateString.dropFirst(8).dropLast(14)
+        let year = dateString.dropText(first: 2, last: 20)
+        let month = dateString.dropText(first: 5, last: 17)
+        let day = dateString.dropText(first: 8, last: 14)
 
         return "\(year).\(month).\(day)"
     }
@@ -170,4 +170,10 @@ extension RoomListViewController: UICollectionViewDataSource, UICollectionViewDe
 
 class CustomTapGestureRecognizer: UITapGestureRecognizer {
     var rooms: Room?
+}
+
+extension String {
+    func dropText(first: Int, last: Int) -> Substring {
+        self.dropFirst(first).dropLast(last)
+    }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 코어데이터 삭제, 서버데이터 반영
- Extension 활용으로 Human Error를 줄이기 위함
- 카테고리별시공상황(ChipView)로 데이터(이미지, 텍스트, 카테고리) 바인딩하기 위함.

## Key Changes 🔥 (주요 구현/변경 사항)
- 시공내역뷰(WorkingHistoryView)에서 Status 데이터 Get
  - 시공내역뷰(WorkingHistoryView)에서 전체보기 클릭 시 카테고리별시공상황뷰(ChipView)로 Status 데이터 바인딩
- 카테고리별시공상황뷰(ChipView)에서 게시물과 칩 관련 코어데이터를 서버데이터로 전환(CoreData -> Server)
  - 선택된 게시물(selectedPosts) 배열 생성
  - `전체`를 제외한 `나머지 칩`은 selectedPosts를 이용해 구분 및 작업.
- RoomLIstViewController에서 DropLast, DropFirst가 반복되는 것에 대해 Human Error 최소화를 위한 String Extension 생성
 
## ToDo 📆 (남은 작업)
- 없음.

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-04 at 16 54 04](https://user-images.githubusercontent.com/98405970/205480188-c24a961a-a4ac-4860-9953-96dccebb991c.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 서버연결 및 바인딩 작업이 마무리되어갑니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #146.
