### PR TITLE
[Design] 칩뷰 하단 세이프에리어 삭제

### DIFF
--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -92,7 +92,7 @@ class ChipViewController: UIViewController {
         historyView.anchor(
             top:chipScrollView.bottomAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
-            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            bottom: view.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor
         )
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 카테고리별로 시공상태를 보여주는 뷰의 버튼 하단이 오늘의 시공상태를 보여주는 뷰의 버튼 하단과 다르게 잡혀있는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- ChipView의 historyView bottom safeArea 삭제

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
<img width="300" alt="스크린샷 2022-12-07 19 49 16" src="https://user-images.githubusercontent.com/81027256/206159541-26405697-7d57-4c80-bdd6-95aa10ea051f.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 상당히 오랜만에 클라이언트에 PR을 올리게 되네요. 한 줄 밖에 안되는 아주 짧은 레이아웃 수정 코드입니다. 가볍게 보셔도 좋습니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #152.
