### PR TITLE
[Feature] 애플 로그인 기능 추가

### DIFF
--- a/Network/EndPoint/LoginEndPoint.swift
+++ b/Network/EndPoint/LoginEndPoint.swift
@@ -36,7 +36,7 @@ enum LoginEndPoint: EndPointable {
     func getURL(baseURL: String) -> String {
         switch self {
         case .startAppleLogin:
-            return "\(baseURL)/workers"
+            return "\(baseURL)/apple_auth"
         case .addPhoneNumber(let workerID, _):
             return "\(baseURL)/workers/\(workerID)"
         }

--- a/Network/Models/Request/LoginDTO.swift
+++ b/Network/Models/Request/LoginDTO.swift
@@ -8,21 +8,18 @@
 import Foundation
 
 struct LoginDTO: Encodable {
-    var userIdentifier: String
-    var lastName: String?
-    var firstName: String?
-    var email: String?
+    var code: Data?
+    var token: Data?
+    var name: String?
     var number: String?
     
-    init(userIdentifier: String,
-         lastName: String? = nil,
-         firstName: String? = nil,
-         email: String? = nil,
+    init(code: Data? = nil,
+         token: Data? = nil,
+         name: String? = nil,
          number: String? = nil) {
-        self.userIdentifier = userIdentifier
-        self.lastName = lastName
-        self.firstName = firstName
-        self.email = email
+        self.code = code
+        self.token = token
+        self.name = name
         self.number = number
     }
 }

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -794,9 +794,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Samsam/Samsam.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N6LML762WM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = N6LML762WM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Samsam/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 저장을 위해 라이브러리 접근권한이 필요합니다.";
@@ -811,8 +813,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Eddy.Samsam;
+				PRODUCT_BUNDLE_IDENTIFIER = app.samsamhada.giwazip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Samsamhada;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -828,9 +832,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Samsam/Samsam.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N6LML762WM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = N6LML762WM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Samsam/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 저장을 위해 라이브러리 접근권한이 필요합니다.";
@@ -845,8 +851,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Eddy.Samsam;
+				PRODUCT_BUNDLE_IDENTIFIER = app.samsamhada.giwazip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Samsamhada;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Samsam.xcodeproj/project.pbxproj
+++ b/Samsam.xcodeproj/project.pbxproj
@@ -801,6 +801,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = N6LML762WM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Samsam/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "기와집";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 저장을 위해 라이브러리 접근권한이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 업로드를 위해 라이브러리 접근권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -839,6 +840,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = N6LML762WM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Samsam/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "기와집";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 저장을 위해 라이브러리 접근권한이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 업로드를 위해 라이브러리 접근권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Samsam/Assets.xcassets/ColorAsset/giwazipBlue.colorset/Contents.json
+++ b/Samsam/Assets.xcassets/ColorAsset/giwazipBlue.colorset/Contents.json
@@ -1,20 +1,20 @@
 {
-  "colors" : [
-    {
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x7D",
-          "green" : "0x27",
-          "red" : "0x23"
+    "colors": [
+        {
+            "color": {
+                "color-space": "srgb",
+                "components": {
+                    "alpha": "1.000",
+                    "blue": "0x7D",
+                    "green": "0x27",
+                    "red": "0x23"
+                }
+            },
+            "idiom": "universal"
         }
-      },
-      "idiom" : "universal"
+    ],
+    "info": {
+        "author": "xcode",
+        "version": 1
     }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
 }

--- a/Samsam/Assets.xcassets/ColorAsset/giwazipBlue.colorset/Contents.json
+++ b/Samsam/Assets.xcassets/ColorAsset/giwazipBlue.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7E",
+          "green" : "0x21",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samsam/Assets.xcassets/ColorAsset/giwazipBlue.colorset/Contents.json
+++ b/Samsam/Assets.xcassets/ColorAsset/giwazipBlue.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x7E",
-          "green" : "0x21",
-          "red" : "0x1A"
+          "blue" : "0x7D",
+          "green" : "0x27",
+          "red" : "0x23"
         }
       },
       "idiom" : "universal"

--- a/Samsam/Global/AppDelegate.swift
+++ b/Samsam/Global/AppDelegate.swift
@@ -12,6 +12,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // TODO: - [설정] - [Apple ID] - [암호 및 보안] - [내 Apple ID를 사용하는 앱]에서 Apple ID 사용 중단한 후 앱으로 돌아왔을 때 처리 (로그인 페이지로 이동)
         return true
     }
 

--- a/Samsam/Global/Extension/UIColor+.swift
+++ b/Samsam/Global/Extension/UIColor+.swift
@@ -15,4 +15,5 @@ enum AppColor {
     static var unSelectedGray = UIColor(named: "unSelectedGray")
     static var selectedGray = UIColor(named: "selectedGray")
     static var buttonGray = UIColor(named: "buttonGray")
+    static var giwazipBlue = UIColor(named: "giwazipBlue")
 }

--- a/Samsam/Global/SceneDelegate.swift
+++ b/Samsam/Global/SceneDelegate.swift
@@ -14,7 +14,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        let navi = UINavigationController(rootViewController: RoomListViewController())
+        var navi = UINavigationController(rootViewController: RoomListViewController())
+        if UserDefaults.standard.integer(forKey: "workerID") == 0 {
+            navi = UINavigationController(rootViewController: LoginViewController())
+        }
         window?.rootViewController = navi
         window?.makeKeyAndVisible()
     }

--- a/Samsam/ViewController/LoginViewController.swift
+++ b/Samsam/ViewController/LoginViewController.swift
@@ -95,7 +95,6 @@ class LoginViewController: UIViewController {
                 } else {
                     self.navigationController?.pushViewController(RoomListViewController(), animated: true)
                 }
-                print(UserDefaults.standard.string(forKey: "number"))
             } catch NetworkError.serverError {
             } catch NetworkError.encodingError {
             } catch NetworkError.clientError(_) {

--- a/Samsam/ViewController/LoginViewController.swift
+++ b/Samsam/ViewController/LoginViewController.swift
@@ -50,7 +50,7 @@ class LoginViewController: UIViewController {
             top: view.safeAreaLayoutGuide.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingTop: 50,
+            paddingTop: UIScreen.main.bounds.height * 0.06,
             height: UIScreen.main.bounds.width
         )
 

--- a/Samsam/ViewController/LoginViewController.swift
+++ b/Samsam/ViewController/LoginViewController.swift
@@ -15,6 +15,11 @@ class LoginViewController: UIViewController {
     private let loginService: LoginAPI = LoginAPI(apiService: APIService())
     
     // MARK: - View
+    
+    private let appLogo: UIImageView = {
+        $0.image = UIImage(named: "")
+        return $0
+    }(UIImageView())
 
     private lazy var authorizationButton: ASAuthorizationAppleIDButton = {
         $0.addTarget(self, action: #selector(tapAppleLoginButton), for: .touchUpInside)
@@ -33,7 +38,7 @@ class LoginViewController: UIViewController {
     // MARK: - Method
 
     private func attribute() {
-        view.backgroundColor = .white
+        view.backgroundColor = AppColor.giwazipBlue
     }
 
     private func layout() {

--- a/Samsam/ViewController/LoginViewController.swift
+++ b/Samsam/ViewController/LoginViewController.swift
@@ -17,7 +17,8 @@ class LoginViewController: UIViewController {
     // MARK: - View
     
     private let appLogo: UIImageView = {
-        $0.image = UIImage(named: "")
+        $0.image = UIImage(named: "AppIcon")
+        $0.contentMode = .scaleAspectFit
         return $0
     }(UIImageView())
 
@@ -42,7 +43,16 @@ class LoginViewController: UIViewController {
     }
 
     private func layout() {
+        self.view.addSubview(appLogo)
         self.view.addSubview(authorizationButton)
+        
+        appLogo.anchor(
+            top: view.safeAreaLayoutGuide.topAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 50,
+            height: UIScreen.main.bounds.width
+        )
 
         authorizationButton.anchor(
             left: view.safeAreaLayoutGuide.leftAnchor,

--- a/Samsam/ViewController/LoginViewController.swift
+++ b/Samsam/ViewController/LoginViewController.swift
@@ -71,8 +71,16 @@ class LoginViewController: UIViewController {
                     else {return}
                     UserDefaults.standard.setValue(userIdentifier, forKey: "userIdentifier")
                     UserDefaults.standard.setValue(workerID, forKey: "workerID")
+                    if let number = data.number {
+                        UserDefaults.standard.setValue(number, forKey: "number")
+                    }
                 }
-                self.navigationController?.pushViewController(PhoneNumViewController(), animated: true)
+                if UserDefaults.standard.string(forKey: "number") == nil {
+                    self.navigationController?.pushViewController(PhoneNumViewController(), animated: true)
+                } else {
+                    self.navigationController?.pushViewController(RoomListViewController(), animated: true)
+                }
+                print(UserDefaults.standard.string(forKey: "number"))
             } catch NetworkError.serverError {
             } catch NetworkError.encodingError {
             } catch NetworkError.clientError(_) {

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -159,8 +159,6 @@ class PhoneNumViewController: UIViewController {
 
     @objc private func tapSubmitButton() {
         let number = "+82010" + phoneNum
-        let loginDTO = LoginDTO(userIdentifier: UserDefaults.standard.string(forKey: "userIdentifier")!, number: number)
-        requestPutPhoneNumber(workerID: Int(UserDefaults.standard.string(forKey: "workerID")!)!, LoginDTO: loginDTO)
         let roomListViewController = RoomListViewController()
         navigationController?.pushViewController(roomListViewController, animated: true)
     }

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -75,6 +75,7 @@ class PhoneNumViewController: UIViewController {
 
     private func attribute() {
         view.backgroundColor = .white
+        navigationItem.hidesBackButton = true
     }
 
     private func layout() {

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -11,7 +11,7 @@ class RoomListViewController: UIViewController {
 
     // MARK: - Property
 
-    var workerID = 5
+    var workerID = UserDefaults.standard.integer(forKey: "workerID")
     let roomAPI: RoomAPI = RoomAPI(apiService: APIService())
     var rooms = [Room]() {
         didSet {
@@ -35,7 +35,7 @@ class RoomListViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        loadRoomByWorkerID(workerID: 5)
+        loadRoomByWorkerID(workerID: workerID)
     }
 
     // MARK: - Method

--- a/Samsam/ViewController/RoomListViewController.swift
+++ b/Samsam/ViewController/RoomListViewController.swift
@@ -67,6 +67,7 @@ class RoomListViewController: UIViewController {
         navigationItem.title = "기와집"
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationItem.hidesBackButton = true
     }
 
     @objc func tapSettingButton() {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 애플 로그인으로 회원 가입 및 로그인을 하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- LoginDTO 변경 (기존: worker 테이블 정보 -> 변경: AuthorizationCode, idToken, userName)
- LoginEndPoint 주소 변경
- RoomList에서 5번 방이 아닌, UserDefaults에 저장된 값을 가져오도록 변경
- 앱 첫 실행인지에 따라 RoomListView와 LoginView로 분기
- LoginView에서 서버에 업자 전화번호가 있는지 없는지에 따라 PhoneNumView와 RoomListView로 분기
- LoginView, PhoneNumView에서 다음 뷰로 넘어갈 시 navigation back button 삭제
- 앱 디스플레이 이름 변경
- 앱 메인 컬러 추가
- 로그인 뷰에 새로운 디자인 적용

## ToDo 📆 (남은 작업)
- [x] 앱 첫 실행 여부에 따라 LoginView, RoomListView 분기 (76aa640)
- [x] 업자 전화번호 저장 여부에 따라 PhoneNumView, RoomListView 분기 (766e06f)
- [x] LoginView, PhoneNumView에서 다음 뷰로 넘어갈 시 navigation back button 삭제 (04a01bf)

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/206228313-86897289-fe2b-4451-b366-50dd2c1d1e56.gif" width="300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 드디어 로그인 기능이 끝났습니다...
- 정석적인 방법이라기 보다는 우선 로그인 및 회원가입이 되는 반쪽짜리 기능이지만, 나중에 정식으로 수정하도록 하겠습니다.
- RoomList에서도 현재 로그인한 업자의 방으로 출력되도록 변경했습니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
- Close #15.
