### PR TITLE
[Design] 문의내역뷰(InquiryView) 생성, HistoryView들에 문구 추가

### DIFF
--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -13,7 +13,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 
     let screenWidth = UIScreen.main.bounds.width - 32
 
-    private var naviTitle = "화장실"
+    private var naviTitle = ""
     var images: [Photo] = []
     private var sharingItems: [Any] = []
 

--- a/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
+++ b/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
@@ -246,6 +246,7 @@ class SegmentedControlViewController: UIViewController {
     
     private func loadInquiryView() {
         inquiryHistoryView.room = room
+        inquiryHistoryView.pleaseWriteLabel.text = "아직 문의내역이 없어요"
     }
 }
 

--- a/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
+++ b/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
@@ -234,7 +234,7 @@ class SegmentedControlViewController: UIViewController {
         }
     }
     
-    func loadStatusesByRoomID(roomID: Int) {
+    private func loadStatusesByRoomID(roomID: Int) {
         Task {
             let response = try await self.roomAPI.loadStatusesByRoomID(roomID: room!.roomID)
             guard let data = response else {

--- a/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
+++ b/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
@@ -21,6 +21,7 @@ class SegmentedControlViewController: UIViewController {
     var posts = [Post]() {
         didSet {
             workingHistoryView.posts = []
+            inquiryHistoryView.posts = []
             posts.sort(by: {$0.postID > $1.postID})
             posts.forEach {
                 if $0.type == 0 {

--- a/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
+++ b/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
@@ -46,10 +46,12 @@ class SegmentedControlViewController: UIViewController {
 
     private lazy var workingHistoryView: WorkingHistoryViewController = {
         $0.room = room
+        $0.isChangedSegment = true
         return $0
     }(WorkingHistoryViewController())
 
     private let inquiryHistoryView: WorkingHistoryViewController = {
+        $0.isChangedSegment = false
         return $0
     }(WorkingHistoryViewController())
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/UIComponent/WorkingHistoryViewContentCell.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/UIComponent/WorkingHistoryViewContentCell.swift
@@ -32,7 +32,7 @@ class WorkingHistoryViewContentCell: UICollectionViewCell {
         return $0
     }(UILabel())
 
-    private let workTypeView: UIView = {
+    let workTypeView: UIView = {
         $0.backgroundColor = .white
         $0.layer.borderColor = AppColor.campanulaBlue?.cgColor
         $0.layer.borderWidth = 2

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -54,7 +54,6 @@ class WorkingHistoryViewController: UIViewController {
         super.viewDidLoad()
         attribute()
         layout()
-        loadStatusesByRoomID(roomID: room!.roomID)
     }
 
     // MARK: - Method
@@ -81,16 +80,6 @@ class WorkingHistoryViewController: UIViewController {
             bottom: view.bottomAnchor,
             right: view.rightAnchor
         )
-    }
-    
-    func loadStatusesByRoomID(roomID: Int) {
-        Task {
-            let response = try await self.roomAPI.loadStatusesByRoomID(roomID: room!.roomID)
-            guard let data = response else {
-                return
-            }
-            statuses = data
-        }
 
         pleaseWriteLabel.anchor(
             top: view.topAnchor,

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -213,7 +213,6 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section > 0 {
             let detailViewController = DetailViewController()
-            
             detailViewController.descriptionLBL.text = everyDayPosts[indexPath.item].description
             
             everyDayPosts[indexPath.item].photos!.forEach {

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -28,8 +28,8 @@ class WorkingHistoryViewController: UIViewController {
     var isChangedSegment: Bool = true
     var dateArray: [String] = []
     var room: Room?
-    private var postDate = Set<String>()
-    
+    var postDate = Set<String>()
+
     // MARK: - View
 
     private let workingHistoryView: UICollectionView = {
@@ -37,7 +37,7 @@ class WorkingHistoryViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
     
-    let pleaseWriteLabel: UILabel = {
+    private let pleaseWriteLabel: UILabel = {
         $0.text = """
                   아직 작업내용이 없어요
                   시공 내용을 작성해주세요!

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -15,7 +15,7 @@ class WorkingHistoryViewController: UIViewController {
     var statuses: [Status]?
     var posts = [Post]() {
         didSet {
-            pleaseWriteLabel.isHidden = (!posts.isEmpty ? true : false)
+            pleaseWriteLabel.isHidden = !posts.isEmpty
 
             posts.forEach {
                 postDate.insert(String($0.createDate.dropLast(14)))

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -26,6 +26,7 @@ class WorkingHistoryViewController: UIViewController {
     }
 
     var isChangedSegment: Bool = true
+    var dateArray: [String] = []
     var room: Room?
     private var dateArray: [String] = []
     private var postDate = Set<String>()

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -160,7 +160,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         } else {
             
             let contentCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewContentCell.identifier, for: indexPath) as! WorkingHistoryViewContentCell
-            
+
             everyDayPosts = []
             
             posts.forEach {

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -27,6 +27,7 @@ class WorkingHistoryViewController: UIViewController {
 
     var isChangedSegment: Bool = true
     var room: Room?
+    private var everyDayPosts: [Post] = []
     private var dateArray: [String] = []
     private var postDate = Set<String>()
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -15,10 +15,12 @@ class WorkingHistoryViewController: UIViewController {
     var statuses: [Status]?
     var posts = [Post]() {
         didSet {
-            workingHistoryView.reloadData()
+            pleaseWriteLabel.isHidden = (!posts.isEmpty ? true : false)
+
             posts.forEach {
                 postDate.insert(String($0.createDate.dropLast(14)))
             }
+            workingHistoryView.reloadData()
         }
     }
     
@@ -31,6 +33,17 @@ class WorkingHistoryViewController: UIViewController {
         return $0
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
+    
+    let pleaseWriteLabel: UILabel = {
+        $0.text = """
+                  아직 작업내용이 없어요
+                  시공 내용을 작성해주세요!
+                  """
+        $0.numberOfLines = 2
+        $0.textColor = .gray
+        $0.textAlignment = .center
+        return $0
+    }(UILabel())
 
     // MARK: - LifeCycle
 
@@ -57,6 +70,7 @@ class WorkingHistoryViewController: UIViewController {
 
     private func layout() {
         view.addSubview(workingHistoryView)
+        view.addSubview(pleaseWriteLabel)
 
         workingHistoryView.anchor(
             top: view.topAnchor,
@@ -74,6 +88,13 @@ class WorkingHistoryViewController: UIViewController {
             }
             statuses = data
         }
+
+        pleaseWriteLabel.anchor(
+            top: view.topAnchor,
+            left: view.leftAnchor,
+            bottom: view.bottomAnchor,
+            right: view.rightAnchor
+        )
     }
 }
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -24,10 +24,10 @@ class WorkingHistoryViewController: UIViewController {
             workingHistoryView.reloadData()
         }
     }
-    var everyDayPosts: [Post] = []
 
     var isChangedSegment: Bool = true
     var room: Room?
+    private var everyDayPosts: [Post] = []
     private var dateArray: [String] = []
     private var postDate = Set<String>()
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -211,8 +211,8 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section > 0 {
             let detailViewController = DetailViewController()
-            var everyDayPosts: [Post] = []
             
+            var everyDayPosts: [Post] = []
             posts.forEach {
                 if dateArray[indexPath.section - 1] == $0.createDate.dropLast(14) {
                     everyDayPosts.append($0)

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -37,7 +37,7 @@ class WorkingHistoryViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
     
-    let pleaseWriteLabel: UILabel = {
+    var pleaseWriteLabel: UILabel = {
         $0.text = """
                   작성된 작업내용이 없어요
                   시공 내용을 작성해주세요!
@@ -136,7 +136,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         }
 
         var everyDayPosts: [Post] = []
-        
+
         posts.forEach {
             if dateArray[section - 1] == $0.createDate.dropLast(14) {
                 everyDayPosts.append($0)

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -26,9 +26,9 @@ class WorkingHistoryViewController: UIViewController {
     }
     
     var isChangedSegment: Bool = true
-    var dateArray: [String] = []
     var room: Room?
-    var postDate = Set<String>()
+    private var dateArray: [String] = []
+    private var postDate = Set<String>()
 
     // MARK: - View
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -24,6 +24,7 @@ class WorkingHistoryViewController: UIViewController {
         }
     }
     
+    var isChangedSegment: Bool = true
     var room: Room?
     private var postDate = Set<String>()
     
@@ -142,13 +143,25 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if indexPath.section == 0 {
             let topCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewTopCell.identifier, for: indexPath) as! WorkingHistoryViewTopCell
-            topCell.viewAll.addTarget(self, action: #selector(tapAllView), for: .touchUpInside)
+
+            if isChangedSegment {
+                topCell.viewAll.addTarget(self, action: #selector(tapAllView), for: .touchUpInside)
+            } else {
+                topCell.isHidden = true
+            }
+
             return topCell
         } else {
             let contentCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewContentCell.identifier, for: indexPath) as! WorkingHistoryViewContentCell
 
             contentCell.imageDescription.text = posts[indexPath.item].description
             contentCell.workType.text = Category.categoryName(Category(rawValue: posts[indexPath.item].category)!)()
+            if isChangedSegment {
+                contentCell.workType.text = Category.categoryName(Category(rawValue: everyDayPosts[indexPath.item].category)!)()
+            } else {
+                contentCell.workType.text = ""
+                contentCell.workTypeView.isHidden = true
+            }
             
             DispatchQueue.global().async {
                 let data = try? Data(contentsOf: URL(string: self.posts[indexPath.item].photos![0].photoPath)!)
@@ -164,7 +177,15 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
 
         if indexPath.section == 0 {
             let width = UIScreen.main.bounds.width
-            let cellHeight = 30
+            var cellHeight = 30
+            
+            if !isChangedSegment {
+                
+                // FIXME: - cellHeight값이 0이면, 게시물이 보이지 않는 문제 식별
+                
+                cellHeight = 1
+            }
+            
             return CGSize(width: Int(width), height: cellHeight)
         } else {
             let width = UIScreen.main.bounds.width - 32

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -37,9 +37,9 @@ class WorkingHistoryViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
     
-    private let pleaseWriteLabel: UILabel = {
+    let pleaseWriteLabel: UILabel = {
         $0.text = """
-                  아직 작업내용이 없어요
+                  작성된 작업내용이 없어요
                   시공 내용을 작성해주세요!
                   """
         $0.numberOfLines = 2

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -134,7 +134,17 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         if section == 0 {
             return 1
         }
-        return posts.count
+
+        // FIXME: - 카운트 바껴야함
+
+        var everyDayPosts: [Post] = []
+
+        posts.forEach {
+            if dateArray[section - 1] == $0.createDate.dropLast(14) {
+                everyDayPosts.append($0)
+            }
+        }
+        return everyDayPosts.count
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -149,10 +159,18 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
 
             return topCell
         } else {
+            
             let contentCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewContentCell.identifier, for: indexPath) as! WorkingHistoryViewContentCell
-
-            contentCell.imageDescription.text = posts[indexPath.item].description
-            contentCell.workType.text = Category.categoryName(Category(rawValue: posts[indexPath.item].category)!)()
+            
+            var everyDayPosts: [Post] = []
+            
+            posts.forEach {
+                if dateArray[indexPath.section - 1] == $0.createDate.dropLast(14) {
+                    everyDayPosts.append($0)
+                }
+            }
+            contentCell.imageDescription.text = everyDayPosts[indexPath.item].description
+            
             if isChangedSegment {
                 contentCell.workType.text = Category.categoryName(Category(rawValue: everyDayPosts[indexPath.item].category)!)()
             } else {
@@ -161,7 +179,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             }
             
             DispatchQueue.global().async {
-                let data = try? Data(contentsOf: URL(string: self.posts[indexPath.item].photos![0].photoPath)!)
+                let data = try? Data(contentsOf: URL(string: everyDayPosts[indexPath.item].photos![0].photoPath)!)
                 DispatchQueue.main.async {
                     contentCell.uiImageView.image = UIImage(data: data!)
                 }

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -213,9 +213,17 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section > 0 {
             let detailViewController = DetailViewController()
-            detailViewController.descriptionLBL.text = posts[indexPath.item].description
+            var everyDayPosts: [Post] = []
             
-            posts[indexPath.item].photos!.forEach {
+            posts.forEach {
+                if dateArray[indexPath.section - 1] == $0.createDate.dropLast(14) {
+                    everyDayPosts.append($0)
+                }
+            }
+            
+            detailViewController.descriptionLBL.text = everyDayPosts[indexPath.item].description
+            
+            everyDayPosts[indexPath.item].photos!.forEach {
                 detailViewController.images.append($0)
             }
             navigationController?.pushViewController(detailViewController, animated: true)

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -26,6 +26,7 @@ class WorkingHistoryViewController: UIViewController {
     }
 
     var isChangedSegment: Bool = true
+    var dateArray: [String] = []
     var room: Room?
     private var everyDayPosts: [Post] = []
     private var dateArray: [String] = []

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -39,7 +39,7 @@ class WorkingHistoryViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
     
-    let pleaseWriteLabel: UILabel = {
+    private let pleaseWriteLabel: UILabel = {
         $0.text = """
                   작성된 작업내용이 없어요
                   시공 내용을 작성해주세요!

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -118,8 +118,8 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
 
         if indexPath.section == 0 {
             let topHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: WorkingHistoryViewTopHeader.identifier, for: indexPath) as! WorkingHistoryViewTopHeader
-
-            topHeader.progressDuration.text = "진행상황(10.11 ~ 11.12)"
+            
+            topHeader.progressDuration.text = "진행상황(\(String((room?.startDate.dropText(first: 2, last: 14).replacingOccurrences(of: "-", with: "."))!)) ~ \(String((room?.endDate.dropText(first: 2, last: 14).replacingOccurrences(of: "-", with: "."))!)))"
 
             return topHeader
         } else {

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -20,11 +20,13 @@ class WorkingHistoryViewController: UIViewController {
             posts.forEach {
                 postDate.insert(String($0.createDate.dropLast(14)))
             }
+            dateArray = postDate.sorted(by: {$0 > $1})
             workingHistoryView.reloadData()
         }
     }
     
     var isChangedSegment: Bool = true
+    var dateArray: [String] = []
     var room: Room?
     private var postDate = Set<String>()
     
@@ -124,9 +126,15 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             return topHeader
         } else {
             let contentHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: WorkingHistoryViewContentHeader.identifier, for: indexPath) as! WorkingHistoryViewContentHeader
-            
-            contentHeader.uploadDate.text = "12월 10일"
 
+            var createDates = dateArray[indexPath.section - 1]
+            createDates.insert("년", at: createDates.index(createDates.startIndex, offsetBy: 4))
+            createDates.insert("월", at: createDates.index(createDates.startIndex, offsetBy: 8))
+            createDates.insert("일", at: createDates.index(createDates.startIndex, offsetBy: 12))
+            createDates = createDates.dropFirst(2).replacingOccurrences(of: "-", with: " ")
+
+            contentHeader.uploadDate.text = createDates
+            
             return contentHeader
         }
     }

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -212,6 +212,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section > 0 {
             let detailViewController = DetailViewController()
+
             detailViewController.descriptionLBL.text = everyDayPosts[indexPath.item].description
             
             everyDayPosts[indexPath.item].photos!.forEach {

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -39,7 +39,7 @@ class WorkingHistoryViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
     
-    private let pleaseWriteLabel: UILabel = {
+    let pleaseWriteLabel: UILabel = {
         $0.text = """
                   작성된 작업내용이 없어요
                   시공 내용을 작성해주세요!

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -24,7 +24,8 @@ class WorkingHistoryViewController: UIViewController {
             workingHistoryView.reloadData()
         }
     }
-    
+    var everyDayPosts: [Post] = []
+
     var isChangedSegment: Bool = true
     var room: Room?
     private var dateArray: [String] = []
@@ -135,9 +136,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             return 1
         }
 
-        // FIXME: - 카운트 바껴야함
-
-        var everyDayPosts: [Post] = []
+        everyDayPosts = []
 
         posts.forEach {
             if dateArray[section - 1] == $0.createDate.dropLast(14) {
@@ -162,7 +161,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             
             let contentCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewContentCell.identifier, for: indexPath) as! WorkingHistoryViewContentCell
             
-            var everyDayPosts: [Post] = []
+            everyDayPosts = []
             
             posts.forEach {
                 if dateArray[indexPath.section - 1] == $0.createDate.dropLast(14) {
@@ -179,7 +178,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             }
             
             DispatchQueue.global().async {
-                let data = try? Data(contentsOf: URL(string: everyDayPosts[indexPath.item].photos![0].photoPath)!)
+                let data = try? Data(contentsOf: URL(string: self.everyDayPosts[indexPath.item].photos![0].photoPath)!)
                 DispatchQueue.main.async {
                     contentCell.uiImageView.image = UIImage(data: data!)
                 }
@@ -213,13 +212,6 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section > 0 {
             let detailViewController = DetailViewController()
-            var everyDayPosts: [Post] = []
-            
-            posts.forEach {
-                if dateArray[indexPath.section - 1] == $0.createDate.dropLast(14) {
-                    everyDayPosts.append($0)
-                }
-            }
             
             detailViewController.descriptionLBL.text = everyDayPosts[indexPath.item].description
             

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -37,7 +37,7 @@ class WorkingHistoryViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
     
-    private let pleaseWriteLabel: UILabel = {
+    let pleaseWriteLabel: UILabel = {
         $0.text = """
                   작성된 작업내용이 없어요
                   시공 내용을 작성해주세요!

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -37,7 +37,7 @@ class WorkingHistoryViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
     
-    let pleaseWriteLabel: UILabel = {
+    private let pleaseWriteLabel: UILabel = {
         $0.text = """
                   작성된 작업내용이 없어요
                   시공 내용을 작성해주세요!

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -26,7 +26,6 @@ class WorkingHistoryViewController: UIViewController {
     }
 
     var isChangedSegment: Bool = true
-    var dateArray: [String] = []
     var room: Room?
     private var everyDayPosts: [Post] = []
     private var dateArray: [String] = []

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -27,7 +27,6 @@ class WorkingHistoryViewController: UIViewController {
 
     var isChangedSegment: Bool = true
     var room: Room?
-    private var everyDayPosts: [Post] = []
     private var dateArray: [String] = []
     private var postDate = Set<String>()
 
@@ -136,8 +135,8 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             return 1
         }
 
-        everyDayPosts = []
-
+        var everyDayPosts: [Post] = []
+        
         posts.forEach {
             if dateArray[section - 1] == $0.createDate.dropLast(14) {
                 everyDayPosts.append($0)
@@ -161,8 +160,8 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             
             let contentCell = collectionView.dequeueReusableCell(withReuseIdentifier: WorkingHistoryViewContentCell.identifier, for: indexPath) as! WorkingHistoryViewContentCell
 
-            everyDayPosts = []
-            
+            var everyDayPosts: [Post] = []
+
             posts.forEach {
                 if dateArray[indexPath.section - 1] == $0.createDate.dropLast(14) {
                     everyDayPosts.append($0)
@@ -178,7 +177,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             }
             
             DispatchQueue.global().async {
-                let data = try? Data(contentsOf: URL(string: self.everyDayPosts[indexPath.item].photos![0].photoPath)!)
+                let data = try? Data(contentsOf: URL(string: everyDayPosts[indexPath.item].photos![0].photoPath)!)
                 DispatchQueue.main.async {
                     contentCell.uiImageView.image = UIImage(data: data!)
                 }
@@ -212,7 +211,14 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section > 0 {
             let detailViewController = DetailViewController()
-
+            var everyDayPosts: [Post] = []
+            
+            posts.forEach {
+                if dateArray[indexPath.section - 1] == $0.createDate.dropLast(14) {
+                    everyDayPosts.append($0)
+                }
+            }
+            
             detailViewController.descriptionLBL.text = everyDayPosts[indexPath.item].description
             
             everyDayPosts[indexPath.item].photos!.forEach {

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -168,7 +168,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
                 }
             }
             contentCell.imageDescription.text = everyDayPosts[indexPath.item].description
-            
+
             if isChangedSegment {
                 contentCell.workType.text = Category.categoryName(Category(rawValue: everyDayPosts[indexPath.item].category)!)()
             } else {

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -26,7 +26,6 @@ class WorkingHistoryViewController: UIViewController {
     }
 
     var isChangedSegment: Bool = true
-    var dateArray: [String] = []
     var room: Room?
     private var dateArray: [String] = []
     private var postDate = Set<String>()


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 코드 반복을 줄이기 위한 workingHistoryView 재사용
- 시공 내역 및 문의 내역이 없을 때 기본 문구 보여주기 위함.
- 생성일에 일치하는 게시물을 보여주기 위함
- DetailView에서 Back버튼 클릭 시, DetailView 문구가 잠시 나타나는 문제를 제거하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 시공내역뷰(workingHistory)를 이용한 문의내역뷰(InquiryView) 생성
- 문의내역 및 시공내역뷰에 "시공내용을 추가해주세요" 문구 추가
- 생성일에 따른 섹션 구분
- 생성일과 일치하는 섹션에 맞게 게시물 보여주기
- DetailView의 네비게이션 타이틀 문구 삭제했습니다.

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-08 at 00 40 37](https://user-images.githubusercontent.com/98405970/206223618-94899622-729a-4b1c-81bc-72406983e6cc.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 뷰만 만들려다가 보니 서버연동을 하게 되고, 서버연동을 하다보니 여러 코드를 건드리게 되어버렸네요..

## Close Issues 🔒 (닫을 Issue)
Close #149.
