### PR TITLE
[Design] HistoryView들 게시글 수정

### DIFF
--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/UIComponent/WorkingHistoryViewContentCell.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/UIComponent/WorkingHistoryViewContentCell.swift
@@ -19,18 +19,9 @@ class WorkingHistoryViewContentCell: UICollectionViewCell {
         $0.image = UIImage(named: "GrayBox")
         $0.layer.masksToBounds = true
         $0.layer.cornerRadius = 16
-        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         $0.contentMode = .scaleAspectFill
         return $0
     }(UIImageView())
-
-    let imageDescription: UILabel = {
-        $0.text = "애플, 동아시아 최초 '디벨로퍼 아카데미' 한국서 운영"
-        $0.textAlignment = .left
-        $0.numberOfLines = 2
-        $0.font = UIFont.systemFont(ofSize: 16, weight: .regular)
-        return $0
-    }(UILabel())
 
     let workTypeView: UIView = {
         $0.backgroundColor = .white
@@ -48,21 +39,20 @@ class WorkingHistoryViewContentCell: UICollectionViewCell {
         return $0
     }(UILabel())
 
-    private let vStack: UIStackView = {
-        $0.backgroundColor = .white
-        $0.axis = .vertical
-        $0.layer.masksToBounds = false
-        $0.layer.cornerRadius = 16
-        $0.layer.shadowColor = UIColor.black.cgColor
-        $0.layer.shadowOpacity = 0.2
-        $0.layer.shadowRadius = 20
-        $0.layer.shadowOffset = CGSize(width: 4, height: 4)
-        return $0
-    }(UIStackView())
-
     private let descriptionCoverView: UIView = {
+        $0.backgroundColor = .black
+        $0.layer.opacity = 0.7
         return $0
     }(UIView())
+    
+    let imageDescription: UILabel = {
+        $0.text = ""
+        $0.textColor = .white
+        $0.textAlignment = .left
+        $0.numberOfLines = 2
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        return $0
+    }(UILabel())
 
     // MARK: - Init
 
@@ -78,27 +68,18 @@ class WorkingHistoryViewContentCell: UICollectionViewCell {
     // MARK: - Method
 
     private func layout() {
-        addSubview(vStack)
-        vStack.addArrangedSubview(uiImageView)
+        addSubview(uiImageView)
         uiImageView.addSubview(workTypeView)
         workTypeView.addSubview(workType)
-        vStack.addArrangedSubview(descriptionCoverView)
-        descriptionCoverView.addSubview(imageDescription)
+        uiImageView.addSubview(descriptionCoverView)
+        addSubview(imageDescription)
 
-        vStack.anchor(
+        uiImageView.anchor(
             top: topAnchor,
             left: leftAnchor,
             bottom: bottomAnchor,
             right: rightAnchor
         )
-
-        uiImageView.anchor(
-            top: vStack.topAnchor,
-            left: vStack.leftAnchor,
-            right: vStack.rightAnchor
-        )
-
-        uiImageView.heightAnchor.constraint(lessThanOrEqualToConstant: (UIScreen.main.bounds.width - 32) / 4 * 3).isActive = true
 
         workTypeView.anchor(
             top: uiImageView.topAnchor,
@@ -119,10 +100,9 @@ class WorkingHistoryViewContentCell: UICollectionViewCell {
         )
 
         descriptionCoverView.anchor(
-            top: uiImageView.bottomAnchor,
-            left: vStack.leftAnchor,
-            bottom: vStack.bottomAnchor,
-            right: vStack.rightAnchor
+            left: uiImageView.leftAnchor,
+            bottom: uiImageView.bottomAnchor,
+            right: uiImageView.rightAnchor
         )
 
         imageDescription.anchor(
@@ -130,12 +110,10 @@ class WorkingHistoryViewContentCell: UICollectionViewCell {
             left: descriptionCoverView.leftAnchor,
             bottom: descriptionCoverView.bottomAnchor,
             right: descriptionCoverView.rightAnchor,
-            paddingTop: 6,
-            paddingLeft: 6,
-            paddingBottom: 6,
-            paddingRight: 6
+            paddingTop: 12,
+            paddingLeft: 12,
+            paddingBottom: 12,
+            paddingRight: 12
         )
-        descriptionCoverView.setContentCompressionResistancePriority(UILayoutPriority(751), for: .vertical)
-        imageDescription.setContentCompressionResistancePriority(UILayoutPriority(752), for: .vertical)
     }
 }

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/UIComponent/WorkingHistoryViewContentCell.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/UIComponent/WorkingHistoryViewContentCell.swift
@@ -72,7 +72,7 @@ class WorkingHistoryViewContentCell: UICollectionViewCell {
         uiImageView.addSubview(workTypeView)
         workTypeView.addSubview(workType)
         uiImageView.addSubview(descriptionCoverView)
-        addSubview(imageDescription)
+        uiImageView.addSubview(imageDescription)
 
         uiImageView.anchor(
             top: topAnchor,

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -203,7 +203,7 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
             return CGSize(width: Int(width), height: cellHeight)
         } else {
             let width = UIScreen.main.bounds.width - 32
-            let cellHeight = width / 4 * 3 + 30
+            let cellHeight = width / 4 * 3
 
             return CGSize(width: Int(width), height: Int(cellHeight))
         }
@@ -235,5 +235,9 @@ extension WorkingHistoryViewController: UICollectionViewDataSource, UICollection
         chipViewController.posts = posts
         chipViewController.statuses = statuses
         navigationController?.pushViewController(chipViewController , animated: true)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 20
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 게시물의 글 범위가 이미지 크기마다 달라지는 문제 해결하기 위함
- Hifi디자인으로 수정하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 게시물 사이즈 4:3으로 수정
- 이미지 범위 안에 descriptionCoverView를 넣어, Radius가 같이 반영되도록 수정
- descriptionCoverView opercity 및 색상 반영
- imageDescription 기본 문구 삭제

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-08 at 12 00 02](https://user-images.githubusercontent.com/98405970/206345493-ebebb3bc-dbc8-4426-8e5e-1690117b4ba5.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 코드입니다. 편한 관람되십쇼!

## Close Issues 🔒 (닫을 Issue)
Close #129 #162 .
