### PR TITLE
[Design] 새로운 디자인에 맞게 게시물 상세 페이지 수정

### DIFF
--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -11,7 +11,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
 
     // MARK: - Property
 
-    let screenWidth = UIScreen.main.bounds.width - 32
+    let screenWidth = UIScreen.main.bounds.width
 
     private var naviTitle = ""
     var images: [Photo] = []
@@ -30,7 +30,6 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         $0.isScrollEnabled = true
         $0.showsHorizontalScrollIndicator = false
         $0.isPagingEnabled = true
-        $0.layer.cornerRadius = 16
         return $0
     }(UIScrollView())
 
@@ -51,8 +50,6 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             width: screenWidth,
             height: screenWidth / 5 * 2
         )
-        $0.layer.cornerRadius = 16
-        $0.backgroundColor = .lightGray
         return $0
     }(UIScrollView())
 
@@ -178,8 +175,6 @@ extension DetailViewController {
             top: view.safeAreaLayoutGuide.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 16,
-            paddingRight: 16,
             height: screenWidth / 4 * 3
         )
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 새로워진 디자인에 맞게 게시물 상세 페이지를 보여주기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- DetailView Layout 수정

## ToDo 📆 (남은 작업)
- [ ] pageControl 사진으로 변경

## ScreenShot 📷 (참고 사진)
<img width="300" alt="스크린샷 2022-12-08 17 41 07" src="https://user-images.githubusercontent.com/81027256/206399411-3eb06671-74b3-4dd9-aca4-0dfe18af3a9c.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 새로운 디자인에 맞게 게시물 상세 페이지 레이아웃의 일부를 수정했습니다.
- 페이지 컨트롤 부분은 빠른 작업이 불가능해, 후에 작업하여 올리겠습니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #No.
