### PR TITLE
[Design] 버튼 디자인 수정 및 버튼 뒤로 게시물이 가려지는 문제 해결

### DIFF
--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -101,6 +101,7 @@ class ChipViewController: UIViewController {
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingLeft: 16,
+            paddingBottom: 16,
             paddingRight: 16,
             height: 50
         )
@@ -108,7 +109,8 @@ class ChipViewController: UIViewController {
 
     private func attribute() {
         view.backgroundColor = .white
-
+        historyView.contentInset.bottom = 80
+        
         setChip()
 
         historyView.delegate = self

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -215,7 +215,7 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
 
         let width = UIScreen.main.bounds.width - 32
-        let cellHeight = width / 4 * 3 + 30
+        let cellHeight = width / 4 * 3
         return CGSize(width: Int(width), height: Int(cellHeight))
     }
 
@@ -231,5 +231,9 @@ extension ChipViewController: UICollectionViewDataSource, UICollectionViewDelega
         }
         
         navigationController?.pushViewController(detailViewController, animated: true)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 20
     }
 }

--- a/Samsam/ViewController/ChipViewController.swift
+++ b/Samsam/ViewController/ChipViewController.swift
@@ -40,6 +40,12 @@ class ChipViewController: UIViewController {
     }(UICollectionView(
         frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()))
 
+    private let buttonBackgroundView: UIView = {
+        $0.backgroundColor = .white
+        $0.layer.opacity = 0.85
+        return $0
+    }(UIView())
+    
     private lazy var writingButton: UIButton = {
         $0.backgroundColor = AppColor.campanulaBlue
         $0.setTitle("시공상황 작성하기", for: .normal)
@@ -70,6 +76,7 @@ class ChipViewController: UIViewController {
         view.addSubview(chipScrollView)
         chipScrollView.addSubview(chipContentView)
         view.addSubview(historyView)
+        view.addSubview(buttonBackgroundView)
         view.addSubview(writingButton)
 
         chipScrollView.anchor(
@@ -95,13 +102,21 @@ class ChipViewController: UIViewController {
             bottom: view.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor
         )
+        
+        buttonBackgroundView.anchor(
+            left: view.leftAnchor,
+            bottom: view.bottomAnchor,
+            right: view.rightAnchor
+        )
 
         writingButton.anchor(
+            top: buttonBackgroundView.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 16,
             paddingLeft: 16,
-            paddingBottom: 16,
+            paddingBottom: 8,
             paddingRight: 16,
             height: 50
         )

--- a/Samsam/ViewController/DetailView/DetailViewController.swift
+++ b/Samsam/ViewController/DetailView/DetailViewController.swift
@@ -127,6 +127,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingLeft: 16,
+            paddingBottom: 8,
             paddingRight: 16,
             height: 50
         )

--- a/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
+++ b/Samsam/ViewController/HistoryView/SegmentedControlViewcontroller.swift
@@ -65,17 +65,7 @@ class SegmentedControlViewController: UIViewController {
         return $0
     }(UIPageViewController(transitionStyle: .scroll,
                           navigationOrientation: .horizontal))
-
-    private lazy var writingButton: UIButton = {
-        $0.backgroundColor = AppColor.campanulaBlue
-        $0.setTitle("시공상황 작성하기", for: .normal)
-        $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
-        $0.setTitleColor(.white, for: .normal)
-        $0.layer.cornerRadius = 16
-        $0.addTarget(self, action: #selector(tapWritingButton), for: .touchDown)
-        return $0
-    }(UIButton())
-
+    
     private var currentViewNumber: Int = 0 {
         didSet {
             let direction: UIPageViewController.NavigationDirection = (oldValue <= currentViewNumber ? .forward : .reverse)
@@ -110,8 +100,6 @@ class SegmentedControlViewController: UIViewController {
 
         pageViewController.delegate = self
         pageViewController.dataSource = self
-
-        writingButton.addTarget(self, action: #selector(tapWritingButton), for: .touchDown)
     }
 
     private func layout() {
@@ -119,7 +107,6 @@ class SegmentedControlViewController: UIViewController {
         view.addSubview(pageControlBackgroundView)
         addChild(pageViewController)
         view.addSubview(pageViewController.view)
-        view.addSubview(writingButton)
 
         segmentedControl.anchor(
             top: view.safeAreaLayoutGuide.topAnchor,
@@ -136,7 +123,7 @@ class SegmentedControlViewController: UIViewController {
             bottom: view.bottomAnchor,
             right: view.rightAnchor
         )
-
+        
         pageViewController.view.anchor(
             top: pageControlBackgroundView.topAnchor,
             left: pageControlBackgroundView.leftAnchor,
@@ -144,15 +131,6 @@ class SegmentedControlViewController: UIViewController {
             right: pageControlBackgroundView.rightAnchor
         )
         pageViewController.didMove(toParent: self)
-
-        writingButton.anchor(
-            left: view.safeAreaLayoutGuide.leftAnchor,
-            bottom: view.safeAreaLayoutGuide.bottomAnchor,
-            right: view.safeAreaLayoutGuide.rightAnchor,
-            paddingLeft: 16,
-            paddingRight: 16,
-            height: 50
-        )
     }
 
     private func setNavigationBar() {
@@ -193,15 +171,6 @@ class SegmentedControlViewController: UIViewController {
 
     @objc func changeValue(control: UISegmentedControl) {
         self.currentViewNumber = control.selectedSegmentIndex
-    }
-
-    @objc func tapWritingButton() {
-        let postingCategoryViewController = PostingCategoryViewController()
-        postingCategoryViewController.room = room
-        
-        let navigationController = UINavigationController(rootViewController: postingCategoryViewController)
-        navigationController.modalPresentationStyle = .fullScreen
-        present(navigationController, animated:  true, completion: nil)
     }
     
     private func loadPostByRoomID(roomID: Int) {
@@ -247,6 +216,7 @@ class SegmentedControlViewController: UIViewController {
     private func loadInquiryView() {
         inquiryHistoryView.room = room
         inquiryHistoryView.pleaseWriteLabel.text = "아직 문의내역이 없어요"
+        inquiryHistoryView.writingButton.isHidden = true
     }
 }
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -123,7 +123,7 @@ class WorkingHistoryViewController: UIViewController {
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingTop: 16,
             paddingLeft: 16,
-            paddingBottom: 16,
+            paddingBottom: 8,
             paddingRight: 16,
             height: 50
         )

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -92,7 +92,7 @@ class WorkingHistoryViewController: UIViewController {
 
     private func layout() {
         view.addSubview(workingHistoryView)
-        view.addSubview(pleaseWriteLabel)
+        workingHistoryView.addSubview(pleaseWriteLabel)
         view.addSubview(buttonBackgroundView)
         view.addSubview(writingButton)
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -48,7 +48,12 @@ class WorkingHistoryViewController: UIViewController {
         $0.textAlignment = .center
         return $0
     }(UILabel())
-
+    
+    private let buttonBackgroundView: UIView = {
+        $0.backgroundColor = .white
+        $0.layer.opacity = 0.85
+        return $0
+    }(UIView())
     
     let writingButton: UIButton = {
         $0.backgroundColor = AppColor.campanulaBlue
@@ -88,6 +93,7 @@ class WorkingHistoryViewController: UIViewController {
     private func layout() {
         view.addSubview(workingHistoryView)
         view.addSubview(pleaseWriteLabel)
+        view.addSubview(buttonBackgroundView)
         view.addSubview(writingButton)
 
         workingHistoryView.anchor(
@@ -103,6 +109,13 @@ class WorkingHistoryViewController: UIViewController {
             bottom: view.bottomAnchor,
             right: view.rightAnchor
         )
+        
+        buttonBackgroundView.anchor(
+            left: view.leftAnchor,
+            bottom: view.bottomAnchor,
+            right: view.rightAnchor
+        )
+        
         writingButton.anchor(
             top: buttonBackgroundView.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -48,7 +48,7 @@ class WorkingHistoryViewController: UIViewController {
         $0.textAlignment = .center
         return $0
     }(UILabel())
-    
+
     private let buttonBackgroundView: UIView = {
         $0.backgroundColor = .white
         $0.layer.opacity = 0.85
@@ -109,13 +109,13 @@ class WorkingHistoryViewController: UIViewController {
             bottom: view.bottomAnchor,
             right: view.rightAnchor
         )
-        
+
         buttonBackgroundView.anchor(
             left: view.leftAnchor,
             bottom: view.bottomAnchor,
             right: view.rightAnchor
         )
-        
+
         writingButton.anchor(
             top: buttonBackgroundView.topAnchor,
             left: view.safeAreaLayoutGuide.leftAnchor,

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -135,7 +135,7 @@ class WorkingHistoryViewController: UIViewController {
         
         let navigationController = UINavigationController(rootViewController: postingCategoryViewController)
         navigationController.modalPresentationStyle = .fullScreen
-        present(navigationController, animated:  true, completion: nil)
+        present(navigationController, animated:  true)
     }
 }
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -49,6 +49,17 @@ class WorkingHistoryViewController: UIViewController {
         return $0
     }(UILabel())
 
+    
+    let writingButton: UIButton = {
+        $0.backgroundColor = AppColor.campanulaBlue
+        $0.setTitle("시공상황 작성하기", for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.setTitleColor(.white, for: .normal)
+        $0.layer.cornerRadius = 16
+        $0.addTarget(self, action: #selector(tapWritingButton), for: .touchDown)
+        return $0
+    }(UIButton())
+    
     // MARK: - LifeCycle
 
     override func viewDidLoad() {
@@ -70,11 +81,14 @@ class WorkingHistoryViewController: UIViewController {
         workingHistoryView.register(WorkingHistoryViewContentHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: WorkingHistoryViewContentHeader.identifier)
         workingHistoryView.register(WorkingHistoryViewTopCell.self, forCellWithReuseIdentifier: WorkingHistoryViewTopCell.identifier)
         workingHistoryView.register(WorkingHistoryViewContentCell.self, forCellWithReuseIdentifier: WorkingHistoryViewContentCell.identifier)
+        
+        writingButton.addTarget(self, action: #selector(tapWritingButton), for: .touchDown)
     }
 
     private func layout() {
         view.addSubview(workingHistoryView)
         view.addSubview(pleaseWriteLabel)
+        view.addSubview(writingButton)
 
         workingHistoryView.anchor(
             top: view.topAnchor,
@@ -89,6 +103,26 @@ class WorkingHistoryViewController: UIViewController {
             bottom: view.bottomAnchor,
             right: view.rightAnchor
         )
+        writingButton.anchor(
+            top: buttonBackgroundView.topAnchor,
+            left: view.safeAreaLayoutGuide.leftAnchor,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            right: view.safeAreaLayoutGuide.rightAnchor,
+            paddingTop: 16,
+            paddingLeft: 16,
+            paddingBottom: 16,
+            paddingRight: 16,
+            height: 50
+        )
+    }
+    
+    @objc func tapWritingButton() {
+        let postingCategoryViewController = PostingCategoryViewController()
+        postingCategoryViewController.room = room
+        
+        let navigationController = UINavigationController(rootViewController: postingCategoryViewController)
+        navigationController.modalPresentationStyle = .fullScreen
+        present(navigationController, animated:  true, completion: nil)
     }
 }
 

--- a/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
+++ b/Samsam/ViewController/HistoryView/WorkingHistoryView/WorkingHistoryViewController.swift
@@ -64,6 +64,7 @@ class WorkingHistoryViewController: UIViewController {
 
         workingHistoryView.delegate = self
         workingHistoryView.dataSource = self
+        workingHistoryView.contentInset.bottom = 80
 
         workingHistoryView.register(WorkingHistoryViewTopHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: WorkingHistoryViewTopHeader.identifier)
         workingHistoryView.register(WorkingHistoryViewContentHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: WorkingHistoryViewContentHeader.identifier)

--- a/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCategoryViewController.swift
@@ -107,6 +107,7 @@ class RoomCategoryViewController: UIViewController {
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingLeft: 16,
+            paddingBottom: 8,
             paddingRight: 16,
             height: 50
         )

--- a/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCodeViewController.swift
@@ -128,6 +128,7 @@ class RoomCodeViewController: UIViewController {
             bottom: view.safeAreaLayoutGuide.bottomAnchor,
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingLeft: 16,
+            paddingBottom: 8,
             paddingRight: 16,
             height: 50
         )

--- a/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
+++ b/Samsam/ViewController/RoomCreationView/RoomCreationViewContoller.swift
@@ -170,7 +170,7 @@ class RoomCreationViewController: UIViewController{
             right: view.safeAreaLayoutGuide.rightAnchor,
             paddingTop: 10,
             paddingLeft: 16,
-            paddingBottom: 16,
+            paddingBottom: 8,
             paddingRight: 16
         )
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 버튼 뒤 배경 추가하기 위함
- 버튼이 문의내역 뷰에서는 보이지 않기 위함
- 게시물이 버튼 뒤에 가려지는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 버튼 뒤에 white배경을 Opercity(0.85) 반영
- SegmentedControl과 함께 있던 '시공상황 작성하기'버튼을 '문의내역'에서만 보이도록 수정
- WorkingHistoryView, ChipView에 contentInset을 반영해 게시물(CollectionView)의 최하단이 버튼보다 위로 올라오도록 수정
- 기존 디자인에서 버튼이 모두 아래로 내려가있었던 것 같아 HistoryView와 ChipView만 먼저 수정해봤습니다. 이 전이 나으면 원복하겠습니다.

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-08 at 23 25 10](https://user-images.githubusercontent.com/98405970/206471300-bd088d68-367f-40a0-8452-5193205fcc4b.gif)


## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 단순한 코드이동 및 짧은 코드입니다. 편안한 관람되십시오.
- 게시물이 버튼 뒤로 가는 문제만 해결하려고 했으나, 버튼 관련 작업을 함께 처리하다보니 디자인관련 작업이 많아져 Design으로 타이틀을 반영했습니다.
 
## Close Issues 🔒 (닫을 Issue)
Close #169 #167 #85 .
