### PR TITLE
[Fix] 세부이미지뷰(ImageDetailView) 이미지 위치가 특정되지 않는 문제 해결

### DIFF
--- a/Samsam/ViewController/DetailView/ImageDetailViewController.swift
+++ b/Samsam/ViewController/DetailView/ImageDetailViewController.swift
@@ -102,6 +102,7 @@ extension ImageDetailViewController: UIScrollViewDelegate {
     }
     
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
+        view.backgroundColor = .black
         self.scrollView.moveToCenter()
     }
 }

--- a/Samsam/ViewController/DetailView/ImageDetailViewController.swift
+++ b/Samsam/ViewController/DetailView/ImageDetailViewController.swift
@@ -102,25 +102,23 @@ extension ImageDetailViewController: UIScrollViewDelegate {
     }
     
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
-        if let image = detailImage.image {
-            view.backgroundColor = .black
-            
-            let changedWidth = detailImage.frame.width
-            let changedHeight = detailImage.frame.height
-            let fixedWidth = image.size.width
-            let fixedHeight = image.size.height
-            
-            let ratioWidth = changedWidth / fixedWidth
-            let ratioHeight = changedHeight / fixedHeight
-            let ratio = (ratioWidth < ratioHeight) ? ratioWidth : ratioHeight
-            
-            let newWidth = fixedWidth * ratio
-            let newHeight = fixedHeight * ratio
-            
-            let horizontalSide = 0.5 * (newWidth * scrollView.zoomScale > changedWidth ? (newWidth - changedWidth) : (scrollView.frame.width - scrollView.contentSize.width))
-            let verticalSide = 0.5 * (newHeight * scrollView.zoomScale > changedHeight ? (newHeight - changedHeight) : (scrollView.frame.height - scrollView.contentSize.height))
-            
-            scrollView.contentInset = UIEdgeInsets(top: verticalSide, left: horizontalSide, bottom: verticalSide, right: horizontalSide)
+        self.scrollView.moveToCenter()
+    }
+}
+
+extension UIScrollView {
+    func moveToCenter(){
+        let contentWidth = self.contentSize.width;
+        let x = self.bounds.width - contentWidth;
+        
+        let contentHeight = self.contentSize.height;
+        let y = self.bounds.height - contentHeight;
+        
+        guard x > 0 || y > 0 else{
+            self.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0);
+            return;
         }
+        
+        self.contentInset = UIEdgeInsets(top: y / 2, left: x / 2, bottom: 0, right: 0);
     }
 }

--- a/Samsam/ViewController/DetailView/ImageDetailViewController.swift
+++ b/Samsam/ViewController/DetailView/ImageDetailViewController.swift
@@ -61,6 +61,7 @@ class ImageDetailViewController: UIViewController {
             right: scrollView.contentLayoutGuide.rightAnchor
         )
         detailImage.centerX(inView: scrollView)
+        detailImage.centerY(inView: scrollView)
     }
 
     private func attribute() {

--- a/Samsam/ViewController/DetailView/ImageDetailViewController.swift
+++ b/Samsam/ViewController/DetailView/ImageDetailViewController.swift
@@ -102,24 +102,25 @@ extension ImageDetailViewController: UIScrollViewDelegate {
     }
     
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
-        view.backgroundColor = .black
-        self.scrollView.moveToCenter()
-    }
-}
-
-extension UIScrollView {
-    func moveToCenter(){
-        let contentWidth = self.contentSize.width;
-        let x = self.bounds.width - contentWidth;
-        
-        let contentHeight = self.contentSize.height;
-        let y = self.bounds.height - contentHeight;
-        
-        guard x > 0 || y > 0 else{
-            self.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0);
-            return;
+        if let image = detailImage.image {
+            view.backgroundColor = .black
+            
+            let changedWidth = detailImage.frame.width
+            let changedHeight = detailImage.frame.height
+            let fixedWidth = image.size.width
+            let fixedHeight = image.size.height
+            
+            let ratioWidth = changedWidth / fixedWidth
+            let ratioHeight = changedHeight / fixedHeight
+            let ratio = (ratioWidth < ratioHeight) ? ratioWidth : ratioHeight
+            
+            let newWidth = fixedWidth * ratio
+            let newHeight = fixedHeight * ratio
+            
+            let horizontalSide = 0.5 * (newWidth * scrollView.zoomScale > changedWidth ? (newWidth - changedWidth) : (scrollView.frame.width - scrollView.contentSize.width))
+            let verticalSide = 0.5 * (newHeight * scrollView.zoomScale > changedHeight ? (newHeight - changedHeight) : (scrollView.frame.height - scrollView.contentSize.height))
+            
+            scrollView.contentInset = UIEdgeInsets(top: verticalSide, left: horizontalSide, bottom: verticalSide, right: horizontalSide)
         }
-        
-        self.contentInset = UIEdgeInsets(top: y / 2, left: x / 2, bottom: 0, right: 0);
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 이미지 사이즈별 세부이미지뷰(ImageDetailView)에서 특정되지 않는 문제가 식별됨

## Key Changes 🔥 (주요 구현/변경 사항)
- 이미지.centerY가 누락되어 있었기에 수정.

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-12-09 at 00 14 46](https://user-images.githubusercontent.com/98405970/206483195-6bf79431-1273-4298-a728-29eb7a4b0030.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 언제나 버그는 사람의 실수였네요.. ㅠㅠ

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #No.
