### PR TITLE
[!HOTFIX] 회원가입시 전화번호를 입력하지 않고 어플리케이션을 종료하면 후에 수정이 불가능한 버그 수정

### DIFF
--- a/Samsam/Global/SceneDelegate.swift
+++ b/Samsam/Global/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
         var navi = UINavigationController(rootViewController: RoomListViewController())
-        if UserDefaults.standard.integer(forKey: "workerID") == 0 {
+        if (UserDefaults.standard.integer(forKey: "workerID") == 0) || (UserDefaults.standard.string(forKey: "number") == nil) {
             navi = UINavigationController(rootViewController: LoginViewController())
         }
         window?.rootViewController = navi

--- a/Samsam/ViewController/PhoneNumViewController.swift
+++ b/Samsam/ViewController/PhoneNumViewController.swift
@@ -161,6 +161,7 @@ class PhoneNumViewController: UIViewController {
     @objc private func tapSubmitButton() {
         let number = "+82010" + phoneNum
         requestPutPhoneNumber(workerID: UserDefaults.standard.integer(forKey: "workerID"), LoginDTO: LoginDTO(number: number))
+        UserDefaults.standard.setValue(number, forKey: "number")
         let roomListViewController = RoomListViewController()
         navigationController?.pushViewController(roomListViewController, animated: true)
     }

--- a/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
+++ b/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
@@ -20,7 +20,7 @@ class SettingWorkerViewController: UIViewController {
 
     private let tableView = UITableView(frame: .zero, style: .insetGrouped)
     
-    private let data = [["개인 정보 수정"],["고객 센터 문의하기"],["이용 약관","개인정보 처리방침","개발자 정보","버전 정보"],["로그 아웃","회원 탈퇴"]]
+    private let data = [["개인 정보 수정"],["고객 센터 문의하기"],["이용 약관","개인정보 처리방침","개발자 정보","버전 정보"],["로그아웃","회원탈퇴"]]
 
     // MARK: - LifeCycle
 

--- a/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
+++ b/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
@@ -80,7 +80,16 @@ class SettingWorkerViewController: UIViewController {
             }
         }
     }
-    
+
+    private func twoSelectionAlertPresent(title: String = "제목", message: String = "내용", yesString: String = "예", yesAction: ((UIAlertAction) -> Void)? = nil) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let yes = UIAlertAction(title: yesString, style: .destructive, handler: yesAction)
+        let no = UIAlertAction(title: "취소", style: .cancel)
+        alert.addAction(no)
+        alert.addAction(yes)
+        present(alert, animated: true)
+    }
+
     private func logout() {
         UserDefaults.standard.removeObject(forKey: "userIdentifier")
         UserDefaults.standard.removeObject(forKey: "workerID")

--- a/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
+++ b/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
@@ -160,15 +160,17 @@ extension SettingWorkerViewController: UITableViewDataSource, UITableViewDelegat
                 self.logout()
             }
         case [3,1]:
-            let now = Date()
+            twoSelectionAlertPresent(title: "회원탈퇴 하시겠습니까?", message: "회원님의 모든 정보가 삭제됩니다.\n탈퇴 후에는 복구할 수 없습니다.", yesString: "회원탈퇴") { _ in
+                let now = Date()
 
-            let date = DateFormatter()
-            date.locale = Locale(identifier: "ko-kr")
-            date.timeZone = TimeZone(abbreviation: "KST")
-            date.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
-            let myDate = date.string(from: now) + ".withdrawn"
-            modifyWorkerData(workerID: UserDefaults.standard.integer(forKey: "workerID"), WorkerDTO: WorkerDTO(userIdentifier: myDate, name: "", email: "", number: ""))
-            logout()
+                let date = DateFormatter()
+                date.locale = Locale(identifier: "ko-kr")
+                date.timeZone = TimeZone(abbreviation: "KST")
+                date.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+                let myDate = date.string(from: now) + ".withdrawn"
+                self.modifyWorkerData(workerID: UserDefaults.standard.integer(forKey: "workerID"), WorkerDTO: WorkerDTO(userIdentifier: myDate, name: "", email: "", number: ""))
+                self.logout()
+            }
         default:
             break
         }

--- a/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
+++ b/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
@@ -156,7 +156,9 @@ extension SettingWorkerViewController: UITableViewDataSource, UITableViewDelegat
 //            self.navigationController?.pushViewController(VersionViewController(), animated: true)
             print("버전 정보")
         case [3,0]:
-            logout()
+            twoSelectionAlertPresent(title: "로그아웃 하시겠습니까?", message: "앱을 사용하기 위해서는\n다시 로그인하셔야 합니다.", yesString: "로그아웃") { _ in
+                self.logout()
+            }
         case [3,1]:
             let now = Date()
 

--- a/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
+++ b/Samsam/ViewController/SettingView/SettingWorkerViewController.swift
@@ -20,7 +20,7 @@ class SettingWorkerViewController: UIViewController {
 
     private let tableView = UITableView(frame: .zero, style: .insetGrouped)
     
-    private let data = [["개인 정보 수정"],["고객 센터 문의하기"],["이용 약관","개인정보 처리방침","개발자 정보","버전 정보"],["로그아웃","회원탈퇴"]]
+    private let data = [["개인 정보 수정"], ["고객 센터 문의하기"], ["이용 약관", "개인정보 처리방침", "개발자 정보", "버전 정보"], ["로그아웃", "회원탈퇴"]]
 
     // MARK: - LifeCycle
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 회원가입시 전화번호 입력 없이 어플리케이션을 종료한 후, 다시 실행하여 정보를 수정하려하면 어플리케이션이 강제종료되는 버그 수정

## Key Changes 🔥 (주요 구현/변경 사항)
- PhoneNumView에서 어플리케이션 강제 종료시 LoginView로 부터 다시 시작되도록 변경
- 로그아웃 및 회원탈퇴시 바로 로그아웃, 회원탈퇴 되지 않고, 경고창을 먼저 띄워주도록 변경

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/206895565-aa752d64-bf87-4c79-af96-f0ee4a36ef25.gif" width="300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 회원가입시 전화번호 입력 없이 강제 종료하면 생기는 버그를 수정했습니다. 수정이 되는 줄 알고 넘어갔었는데, 뒤늦게 버그를 확인했네요.
- 로그아웃과 회원탈퇴도 바로 되지 않고 경고창을 추가했습니다. 잘 부탁드립니다~

## Reference 🔗
- [아리의 iOS 탐구생활 - [iOS/UIKit] Alert 알림창을 만들어보자](https://leeari95.tistory.com/53)

## Close Issues 🔒 (닫을 Issue)
- Close #189.
